### PR TITLE
Improve panic logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOCMD=go
 BINARY=awsnews
 BUILD_FLAGS=-ldflags="-s -w"
 PROJECT=circa10a/go-aws-news
-VERSION=0.3.0
+VERSION=0.3.1
 
 # First target for travis ci
 test:

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/circa10a/go-aws-news/news"
+	log "github.com/sirupsen/logrus"
 )
 
 // Config is the raw data read from the provider configuration file.
@@ -12,7 +13,7 @@ var Config = readConfig()
 func readConfig() []byte {
 	b, err := ioutil.ReadFile("config.yaml")
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	return b
 }


### PR DESCRIPTION
```log
 ./go-aws-news 
panic: open config.yaml: no such file or directory

goroutine 1 [running]:
github.com/circa10a/go-aws-news/providers.readConfig(0x1d, 0x14f42e0, 0x7)
        /Users/me/Desktop/go-aws-news/providers/providers.go:15 +0x84
github.com/circa10a/go-aws-news/providers.init()
        /Users/me/Desktop/go-aws-news/providers/providers.go:10 +0x22z
```

to

```log
❯ ./go-aws-news
FATA[0000] open config.yaml: no such file or directory  
```