### PR TITLE
Fix news year parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOCMD=go
 BINARY=awsnews
 BUILD_FLAGS=-ldflags="-s -w"
 PROJECT=circa10a/go-aws-news
-VERSION=0.3.2
+VERSION=0.4.0
 
 # First target for travis ci
 test:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Fetch what's new from AWS and send out notifications on social sites.
       - [Get Today's news](#get-todays-news)
       - [Get Yesterday's news](#get-yesterdays-news)
       - [Get all news for the month](#get-all-news-for-the-month)
-      - [Gets from a previous month](#gets-from-a-previous-month)
+      - [Get from a previous month](#get-from-a-previous-month)
+      - [Get from a previous year](#get-from-a-previous-year)
       - [Print out announcements](#print-out-announcements)
       - [Loop over news data](#loop-over-news-data)
       - [Get news as JSON](#get-news-as-json)
@@ -150,11 +151,18 @@ news, _ := awsnews.Yesterday()
 news, _ := awsnews.ThisMonth()
 ```
 
-#### Gets from a previous month
+#### Get from a previous month
 
 ```go
 // Custom timeframe(June 2019)
 news, err := awsnews.Fetch(2019, 06)
+```
+
+#### Get from a previous year
+
+```go
+// Custom timeframe(2017)
+news, err := awsnews.FetchYear(2017)
 ```
 
 #### Print out announcements

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Fetch what's new from AWS and send out notifications on social sites.
       - [Get from a previous year](#get-from-a-previous-year)
       - [Print out announcements](#print-out-announcements)
       - [Loop over news data](#loop-over-news-data)
+      - [Limit news results count](#limit-news-results-count)
       - [Get news as JSON](#get-news-as-json)
       - [Get news as HTML](#get-news-as-html)
       - [Get news about a specific product](#get-news-about-a-specific-product)
@@ -194,6 +195,14 @@ for _, v := range news {
 	fmt.Printf("Link: %v\n", v.Link)
 	fmt.Printf("Date: %v\n", v.PostDate)
 }
+```
+
+#### Limit news results count
+
+```go
+news, _ := awsnews.ThisMonth()
+// Last 10 news items of the month
+news.Last(10).Print()
 ```
 
 #### Get news as JSON

--- a/news/announcements.go
+++ b/news/announcements.go
@@ -137,6 +137,14 @@ func (a Announcements) Print() {
 	table.Render()
 }
 
+// Last returns a set number of news items you specify
+func (a Announcements) Last(n int) Announcements {
+	if len(a) > n {
+		return a[:n]
+	}
+	return a
+}
+
 // JSON Converts Announcements to JSON.
 func (a Announcements) JSON() ([]byte, error) {
 	json, err := json.Marshal(a)

--- a/news/announcements.go
+++ b/news/announcements.go
@@ -39,42 +39,44 @@ func (n newsDoc) GetAnnouncements() (Announcements, error) {
 	return announcements, nil
 }
 
-// Fetch Fetches all of the announcements for the specified year/month that was input.
+// Fetch gets all of the announcements for the specified year/month that was input.
 func Fetch(year int, month int) (Announcements, error) {
-	doc, err := getNewsDoc(year, month)
+	doc, err := getNewsDocMonth(year, month)
 	if err != nil {
 		return Announcements{}, err
 	}
 	return newsDoc{doc}.GetAnnouncements()
 }
 
-// Extract date from amazon's format
-// Input: Posted on: Jan 7, 2020
-// Output: Jan 7, 2020
-// parseDate Extracts a standarized date format from the AWS html document.
-func parseDate(postDate string) string {
-	r, _ := regexp.Compile("[A-Z][a-z]{2}\\s[0-9]{1,2},\\s[0-9]{4}")
-	// AWS sometimes doesn't have a post date
-	if len(r.FindStringSubmatch(postDate)) > 0 {
-		return r.FindStringSubmatch(postDate)[0]
+// FetchYear gets all of the announcements for the specified year that was input.
+func FetchYear(year int) (Announcements, error) {
+	doc, err := getNewsDocYear(year)
+	if err != nil {
+		return Announcements{}, err
 	}
-	return "No posted date"
+	return newsDoc{doc}.GetAnnouncements()
 }
 
 // ThisMonth gets the current month's AWS announcements.
 func ThisMonth() (Announcements, error) {
+	var thisMonthsAnnouncements Announcements
 	currentTime := time.Now()
-	news, err := Fetch(currentTime.Year(), int(currentTime.Month()))
+	news, err := FetchYear(currentTime.Year())
+	for _, announcement := range news {
+		if announcement.PostDate[:3] == currentTime.Month().String()[:3] {
+			thisMonthsAnnouncements = append(thisMonthsAnnouncements, announcement)
+		}
+	}
 	if err != nil {
 		return news, err
 	}
-	return news, nil
+	return thisMonthsAnnouncements, nil
 }
 
 // Today gets today's AWS announcements.
 func Today() (Announcements, error) {
 	var todaysAnnouncements Announcements
-	news, err := ThisMonth()
+	news, err := FetchYear(time.Now().Year())
 	if err != nil {
 		return news, err
 	}
@@ -90,7 +92,7 @@ func Today() (Announcements, error) {
 // Yesterday gets yesterday's AWS announcments.
 func Yesterday() (Announcements, error) {
 	var yesterdaysAnnouncements Announcements
-	news, err := ThisMonth()
+	news, err := FetchYear(time.Now().Year())
 	if err != nil {
 		return news, err
 	}
@@ -101,6 +103,19 @@ func Yesterday() (Announcements, error) {
 		}
 	}
 	return yesterdaysAnnouncements, nil
+}
+
+// Extract date from amazon's format
+// Input: Posted on: Jan 7, 2020
+// Output: Jan 7, 2020
+// parseDate Extracts a standarized date format from the AWS html document.
+func parseDate(postDate string) string {
+	r, _ := regexp.Compile("[A-Z][a-z]{2}\\s[0-9]{1,2},\\s[0-9]{4}")
+	// AWS sometimes doesn't have a post date
+	if len(r.FindStringSubmatch(postDate)) > 0 {
+		return r.FindStringSubmatch(postDate)[0]
+	}
+	return "No posted date"
 }
 
 // Print Prints out an ASCII table of your selection of AWS announcements.

--- a/news/announcements_test.go
+++ b/news/announcements_test.go
@@ -15,6 +15,13 @@ func TestFetch(t *testing.T) {
 	assert.Equal(t, len(news), 100)
 }
 
+// Integration test
+func TestFetchYear(t *testing.T) {
+	news, err := FetchYear(2020)
+	assert.NoError(t, err)
+	assert.Greater(t, len(news), 0)
+}
+
 func TestParseDate(t *testing.T) {
 	assert.Equal(t, "Jan 1, 2020", parseDate("Posted on: Jan 1, 2020"))
 }
@@ -54,21 +61,21 @@ func TestYesterday(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	news, err := newsDoc{testDoc}.GetAnnouncements()
+	news, err := newsDoc{monthTestDoc}.GetAnnouncements()
 	assert.NoError(t, err)
 	_, jsonErr := news.JSON()
 	assert.NoError(t, jsonErr)
 }
 
 func TestHTML(t *testing.T) {
-	news, err := newsDoc{testDoc}.GetAnnouncements()
+	news, err := newsDoc{monthTestDoc}.GetAnnouncements()
 	assert.NoError(t, err)
 	data := []byte(news.HTML())
 	assert.True(t, xml.Unmarshal(data, new(interface{})) == nil)
 }
 
 func TestFilter(t *testing.T) {
-	news, _ := newsDoc{testDoc}.GetAnnouncements()
+	news, _ := newsDoc{monthTestDoc}.GetAnnouncements()
 	filteredNews := news.Filter([]string{"EKS", "ECS"})
 	assert.Equal(t, len(filteredNews), 6)
 }

--- a/news/announcements_test.go
+++ b/news/announcements_test.go
@@ -60,6 +60,12 @@ func TestYesterday(t *testing.T) {
 	}
 }
 
+func TestLast(t *testing.T) {
+	news, err := newsDoc{monthTestDoc}.GetAnnouncements()
+	news = news.Last(5)
+	assert.NoError(t, err)
+	assert.Equal(t, len(news), 5)
+}
 func TestJSON(t *testing.T) {
 	news, err := newsDoc{monthTestDoc}.GetAnnouncements()
 	assert.NoError(t, err)

--- a/news/examples_test.go
+++ b/news/examples_test.go
@@ -10,6 +10,14 @@ func ExampleFetch() {
 	news.Print()
 }
 
+func ExampleFetchYear() {
+	news, err := FetchYear(2020)
+	if err != nil {
+		// Handle error
+	}
+	news.Print()
+}
+
 func ExampleThisMonth() {
 	news, err := ThisMonth()
 	if err != nil {

--- a/news/examples_test.go
+++ b/news/examples_test.go
@@ -44,6 +44,15 @@ func ExampleYesterday() {
 	fmt.Println(news)
 }
 
+func (a Announcements) ExampleLast() {
+	news, err := ThisMonth()
+	if err != nil {
+		// Handle error
+	}
+	// Show last 10 news items of the month
+	news.Last(10).Print()
+}
+
 func (a Announcements) ExampleJSON() {
 	news, err := ThisMonth()
 	if err != nil {

--- a/news/newsdoc.go
+++ b/news/newsdoc.go
@@ -6,8 +6,18 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// getNewsDoc Fetches html from AWS depending on the year/month specified.
-func getNewsDoc(year int, month int) (*goquery.Document, error) {
+// getNewsDocYear Fetches html from AWS depending on the year/month specified.
+func getNewsDocYear(year int) (*goquery.Document, error) {
+	url := fmt.Sprintf("https://aws.amazon.com/about-aws/whats-new/%d", year)
+	doc, err := goquery.NewDocument(url)
+	if err != nil {
+		return doc, err
+	}
+	return doc, nil
+}
+
+// getNewsDocMonth Fetches html from AWS depending on the year/month specified.
+func getNewsDocMonth(year int, month int) (*goquery.Document, error) {
 	url := fmt.Sprintf("https://aws.amazon.com/about-aws/whats-new/%v/%02d/", year, month)
 	doc, err := goquery.NewDocument(url)
 	if err != nil {

--- a/news/newsdoc_test.go
+++ b/news/newsdoc_test.go
@@ -9,45 +9,66 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Reusable html document
-var testDoc *goquery.Document
+// Reusable html documents
+var monthTestDoc *goquery.Document
+var yearTestDoc *goquery.Document
 
 func init() {
 	// create from a file
-	f, err := os.Open("./resources/aws-news-2019-12.html")
+	// Monthly Testing
+	monthFile, err := os.Open("./resources/aws-news-2019-12.html")
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer f.Close()
-	doc, err := goquery.NewDocumentFromReader(f)
+	defer monthFile.Close()
+	monthDoc, err := goquery.NewDocumentFromReader(monthFile)
 	if err != nil {
 		log.Fatal(err)
 	}
-	testDoc = doc
+	monthTestDoc = monthDoc
+
+	// create from a file
+	// yearly Testing
+	yearFile, err := os.Open("./resources/aws-news-2020.html")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer yearFile.Close()
+	yearDoc, err := goquery.NewDocumentFromReader(yearFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	yearTestDoc = yearDoc
 }
 
 // Integration test
-func TestGetNewsDoc(t *testing.T) {
-	_, err := getNewsDoc(2019, 12)
+func TestGetNewsDocMonth(t *testing.T) {
+	_, err := getNewsDocMonth(2019, 12)
+	assert.NoError(t, err)
+}
+
+// Integration
+func TestGetNewsDocYear(t *testing.T) {
+	_, err := getNewsDocYear(2020)
 	assert.NoError(t, err)
 }
 
 func TestGetSelectionItems(t *testing.T) {
-	news := newsDoc{testDoc}
+	news := newsDoc{monthTestDoc}
 	assert.Equal(t, news.getSelectionItems().Length(), 100)
 }
 
 func TestGetSelectionTitle(t *testing.T) {
-	news := newsDoc{testDoc}
+	news := newsDoc{monthTestDoc}
 	assert.Equal(t, news.getSelectionTitle(news.getSelectionItems().First()), "Amazon EKS Announces Beta Release of Amazon FSx for Lustre CSI Driver")
 }
 
 func TestGetSelectionLink(t *testing.T) {
-	news := newsDoc{testDoc}
+	news := newsDoc{monthTestDoc}
 	assert.Equal(t, news.getSelectionItemLink(news.getSelectionItems().First()), "https://aws.amazon.com/about-aws/whats-new/2019/12/amazon-eks-announces-beta-release-amazon-fsx-lustre-csi-driver/")
 }
 
 func TestGetSelectionDate(t *testing.T) {
-	news := newsDoc{testDoc}
+	news := newsDoc{monthTestDoc}
 	assert.Equal(t, news.getSelectionItemDate(news.getSelectionItems().First()), "\n              Posted On: Dec 23, 2019 \n            ")
 }

--- a/news/resources/aws-news-2020.html
+++ b/news/resources/aws-news-2020.html
@@ -1,0 +1,1725 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html class="aws-v1-page no-js aws-lng-en_US" lang="en-US" xmlns="http://www.w3.org/1999/xhtml" data-aws-assets="https://a0.awsstatic.com" data-js-version="1.0.496" data-css-version="1.0.453">
+ <head> 
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8" /> 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" /> 
+  <link rel="dns-prefetch" href="https://a0.awsstatic.com" /> 
+  <link rel="dns-prefetch" href="//d0.awsstatic.com" /> 
+  <link rel="dns-prefetch" href="//d1.awsstatic.com" /> 
+  <title>2020</title> 
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" /> 
+  <meta name="robots" content="index, follow" /> 
+  <link rel="canonical" href="https://aws.amazon.com/about-aws/whats-new/2020/" /> 
+  <link rel="icon" type="image/ico" href="https://a0.awsstatic.com/main/images/site/fav/favicon.ico" /> 
+  <link rel="shortcut icon" type="image/ico" href="https://a0.awsstatic.com/main/images/site/fav/favicon.ico" /> 
+  <link rel="apple-touch-icon" sizes="57x57" href="https://a0.awsstatic.com/main/images/site/touch-icon-iphone-114-smile.png" /> 
+  <link rel="apple-touch-icon" sizes="72x72" href="https://a0.awsstatic.com/main/images/site/touch-icon-ipad-144-smile.png" /> 
+  <link rel="apple-touch-icon" sizes="114x114" href="https://a0.awsstatic.com/main/images/site/touch-icon-iphone-114-smile.png" /> 
+  <link rel="apple-touch-icon" sizes="144x144" href="https://a0.awsstatic.com/main/images/site/touch-icon-ipad-144-smile.png" /> 
+  <meta property="twitter:card" content="summary" /> 
+  <meta property="twitter:title" content="2020" /> 
+  <meta property="twitter:description" content="" /> 
+  <meta property="twitter:image" content="https://a0.awsstatic.com/main/images/logos/aws_logo_smile_179x109.png" /> 
+  <meta property="twitter:site" content="@awscloud" /> 
+  <meta property="og:title" content="2020" /> 
+  <meta property="og:type" content="company" /> 
+  <meta property="og:url" content="https://aws.amazon.com/about-aws/whats-new/2020/" /> 
+  <meta property="og:image" content="https://a0.awsstatic.com/main/images/logos/aws_logo_smile_1200x630.png" /> 
+  <meta property="og:site_name" content="Amazon Web Services, Inc." /> 
+  <meta property="fb:pages" content="153063591397681" /> 
+  <meta name="google-site-verification" content="XHghG81ulgiW-3EylGcF48sG28tBW5EH0bNUhgo_DrU" /> 
+  <meta name="msvalidate.01" content="6F92E52A288E266E30C2797ECB5FCCF3" /> 
+  <meta name="baidu-site-verification" content="pjxJUyWxae" /> 
+  <link rel="alternate" href="//aws.amazon.com/ar/about-aws/whats-new/2020/" hreflang="ar-sa" /> 
+  <link rel="alternate" href="//aws.amazon.com/de/about-aws/whats-new/2020/" hreflang="de-de" /> 
+  <link rel="alternate" href="//aws.amazon.com/about-aws/whats-new/2020/" hreflang="en-us" /> 
+  <link rel="alternate" href="//aws.amazon.com/es/about-aws/whats-new/2020/" hreflang="es-es" /> 
+  <link rel="alternate" href="//aws.amazon.com/fr/about-aws/whats-new/2020/" hreflang="fr-fr" /> 
+  <link rel="alternate" href="//aws.amazon.com/id/about-aws/whats-new/2020/" hreflang="id-id" /> 
+  <link rel="alternate" href="//aws.amazon.com/it/about-aws/whats-new/2020/" hreflang="it-it" /> 
+  <link rel="alternate" href="//aws.amazon.com/jp/about-aws/whats-new/2020/" hreflang="ja-jp" /> 
+  <link rel="alternate" href="//aws.amazon.com/ko/about-aws/whats-new/2020/" hreflang="ko-kr" /> 
+  <link rel="alternate" href="//aws.amazon.com/pt/about-aws/whats-new/2020/" hreflang="pt-br" /> 
+  <link rel="alternate" href="//aws.amazon.com/ru/about-aws/whats-new/2020/" hreflang="ru-ru" /> 
+  <link rel="alternate" href="//aws.amazon.com/th/about-aws/whats-new/2020/" hreflang="th-th" /> 
+  <link rel="alternate" href="//aws.amazon.com/tr/about-aws/whats-new/2020/" hreflang="tr-tr" /> 
+  <link rel="alternate" href="//aws.amazon.com/vi/about-aws/whats-new/2020/" hreflang="vi-vn" /> 
+  <link rel="alternate" href="//aws.amazon.com/cn/about-aws/whats-new/2020/" hreflang="zh-cn" /> 
+  <link rel="alternate" href="//aws.amazon.com/tw/about-aws/whats-new/2020/" hreflang="zh-tw" /> 
+  <link rel="stylesheet" href="https://a0.awsstatic.com/main/css/1.0.453/style.css" /> 
+  <script>
+    var AWS = {
+      PageSettings: {
+        supportedLanguages: ['ar', 'en', 'es', 'de', 'fr', 'id', 'it', 'jp', 'ko', 'pt', 'ru', 'th', 'tr', 'vi', 'cn', 'tw'],
+        defaultLanguage: 'en',
+        logDataSet: 'LIVE:PROD',
+        logInstance: 'PUB',
+        csdsEndpoint: 'https://aws.amazon.com/',
+        framework: 'v1',
+        g11nLibPath: 'https://a0.awsstatic.com/g11n-lib/2.0.50',
+        i18nStringPath: 'https://i18n-string.us-west-2.prod.pricing.aws.a2z.com',
+        libraCSSPath: 'https://a0.awsstatic.com/libra-css/css/1.0.330',
+        isLoggingEnabled: true,
+        currentLanguage: 'en-US',
+        isRTL: false
+      },
+    };
+
+    var require = {
+      baseUrl: "https://a0.awsstatic.com/chrome/js/1.0.496/",
+      paths: {
+        "jquery": "jquery-amd",
+        "psf": "https://a0.awsstatic.com/psf/1.1.7",
+        "plc": "https://a0.awsstatic.com/plc/js/1.0.93/plc",
+        "directories": "https://a0.awsstatic.com/libra/1.0.322/directories",
+        "libra": "https://a0.awsstatic.com/libra/1.0.322",
+        "libra-cardsui": "https://a0.awsstatic.com/libra/1.0.322/libra-cardsui",
+        "librastandardlib": "https://a0.awsstatic.com/libra/1.0.322/librastandardlib"
+      },
+      deps: ["scripts"],
+      shim: {
+        "scripts": ["jquery"],
+        "forms": ["jquery"],
+        "pricing-table": ["jquery", "scripts"],
+        "plugins/bootstrap.button": ["jquery"],
+        "plugins/bootstrap.collapse": ["jquery"],
+        "plugins/bootstrap.dropdown": ["jquery"],
+        "plugins/bootstrap.popover": ["jquery"],
+        "plugins/bootstrap.tab": ["jquery"],
+        "plugins/bootstrap.tooltip": ["jquery"],
+        "plugins/free-tier": ["jquery", "scripts"],
+        "plugins/jquery.caroufredsel": ["jquery"],
+        "plugins/jquery.fancybox": ["jquery"],
+        "plugins/jwplayer.html5": ["jquery"],
+        "plugins/jwplayer": ["jquery"],
+        "plugins/pbSize": ["jquery"],
+        "plugins/pushstate": ["jquery", "scripts"],
+        "plugins/search-controller": ["jquery"],
+        "plugins/jquery.touchSwipe": ["jquery"]
+      },
+      waitSeconds: 15
+    };
+
+    </script> 
+  <script src="https://a0.awsstatic.com/chrome/js/1.0.496/head.2.0.js"></script> 
+  <script src="https://a0.awsstatic.com/s_code/js/1.0/awshome_s_code.js"></script> 
+  <script>
+      AWS.TargetMediator = {
+        supportedLanguages: AWS.PageSettings.supportedLanguages,holdJqueryReady: true,offerOrigin: 'https://s0.awsstatic.com',pageLanguage: 'en'
+      };
+    </script> 
+  <script data-js-script="target-mediator" src="https://a0.awsstatic.com/target/1.0.102/aws-target-mediator.js"></script> 
+ </head> 
+ <body> 
+  <header id="aws-page-header" class="awsm m-page-header" role="banner"> 
+   <div id="m-nav" class="m-nav" role="navigation"> 
+    <div class="m-nav-header lb-clearfix" data-menu-url="https://s0.awsstatic.com/en_US/nav/v3/panel-content/desktop/index.html"> 
+     <div class="m-nav-logo"> 
+      <div class="lb-bg-logo aws-amazon_web_services_smile-header-desktop-en"> 
+       <a href="https://aws.amazon.com/?nc2=h_lg"><span>Click here to return to Amazon Web Services homepage</span></a> 
+      </div> 
+     </div> 
+     <div class="m-nav-secondary-links" style="min-width: 620px"> 
+      <a href="/contact-us/?nc2=h_header">Contact Sales</a> 
+      <a class="lb-txt-none lb-tiny-iblock lb-txt-13 lb-txt lb-has-trigger-indicator" href="#" data-mbox-ignore="true" data-lb-popover-trigger="popover-support-selector"> Support&nbsp; <i class="icon-caret-down lb-trigger-mount"></i></a> 
+      <a id="m-nav-language-selector" class="lb-tiny-iblock lb-txt lb-has-trigger-indicator" href="#" data-lb-popover-trigger="popover-language-selector" data-language="en">English&nbsp;<i class="icon-caret-down lb-trigger-mount"></i></a> 
+      <a class="lb-tiny-iblock lb-txt lb-has-trigger-indicator" href="#" data-lb-popover-trigger="popover-my-account">My Account&nbsp;<i class="icon-caret-down lb-trigger-mount"></i></a> 
+      <div class="m-nav-cta-btn"> 
+       <div class="lb-mbox js-mbox" data-lb-comp="mbox" data-mbox="en_header_nav_cta" data-lb-comp-ignore="true"> 
+        <div class="lb-btn"> 
+         <a id="aws-nav-cta-button" class="lb-btn-p-primary" href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?nc2=h_ct&amp;src=default" style="min-width:171px;"><span>Create an AWS Account</span></a> 
+        </div> 
+       </div> 
+      </div> 
+     </div> 
+     <div class="m-nav-primary-group"> 
+      <div class="m-nav-primary-links"> 
+       <i class="m-nav-angle-left-icon" aria-hidden="true"></i> 
+       <ul> 
+        <li><a href="/products/?nc2=h_ql_prod" data-panel="m-nav-panel-products">Products</a></li> 
+        <li><a href="/solutions/?nc2=h_ql_sol" data-panel="m-nav-panel-solutions">Solutions</a></li> 
+        <li><a href="/pricing/?nc2=h_ql_pr" data-panel="m-nav-panel-pricing">Pricing</a></li> 
+        <li><a href="https://docs.aws.amazon.com/index.html?nc2=h_ql_doc" data-panel="m-nav-panel-documentation">Documentation</a></li> 
+        <li><a href="/getting-started/?nc2=h_ql_le" data-panel="m-nav-panel-learn">Learn</a></li> 
+        <li><a href="/partners/?nc2=h_ql_pn" data-panel="m-nav-panel-partner">Partner Network</a></li> 
+        <li><a href="https://aws.amazon.com/marketplace/?nc2=h_ql_mp" data-panel="m-nav-panel-marketplace">AWS Marketplace</a></li> 
+        <li><a href="/customer-enablement/?nc2=h_ql_ce" data-panel="m-nav-panel-customer">Customer Enablement</a></li> 
+        <li><a href="/events/?nc2=h_ql_ev" data-panel="m-nav-panel-events">Events</a></li> 
+        <li><a href="/contact-us/?nc2=h_ql_exm" data-panel="m-nav-panel-more">Explore More </a></li> 
+       </ul> 
+       <div class="m-nav-icon-group"> 
+        <i class="m-nav-angle-right-icon" aria-hidden="true"></i> 
+        <i class="m-nav-search-icon"></i> 
+       </div> 
+      </div> 
+      <div class="m-nav-search"> 
+       <form action="https://aws.amazon.com/search" role="search"> 
+        <div class="m-typeahead" data-directory-id="typeahead-suggestions" data-lb-comp="typeahead"> 
+         <input class="m-nav-search-field" placeholder="Search" autocomplete="off" spellcheck="false" dir="auto" type="text" name="searchQuery" /> 
+        </div> 
+       </form> 
+       <i class="m-nav-close-icon"></i> 
+      </div> 
+     </div> 
+    </div> 
+    <div class="lb-popover lb-popover-aui lb-popover-tiny" data-lb-comp="popover" data-id="popover-language-selector" data-action="hover" data-position="top"> 
+     <div class="lb-grid lb-row lb-row-max-large lb-snap"> 
+      <div class="lb-col lb-tiny-24 lb-mid-12"> 
+       <ul class="lb-txt-none lb-ul lb-list-style-none lb-tiny-ul-block"> 
+        <li data-language="ar"> <a href="https://aws.amazon.com/ar/?nc1=h_ls">عربي</a> </li> 
+        <li data-language="id"> <a href="https://aws.amazon.com/id/?nc1=h_ls">Bahasa Indonesia</a> </li> 
+        <li data-language="de"> <a href="https://aws.amazon.com/de/?nc1=h_ls">Deutsch</a> </li> 
+        <li data-language="en"> <a href="https://aws.amazon.com/?nc1=h_ls">English</a> </li> 
+        <li data-language="es"> <a href="https://aws.amazon.com/es/?nc1=h_ls">Espa&ntilde;ol</a> </li> 
+        <li data-language="fr"> <a href="https://aws.amazon.com/fr/?nc1=h_ls">Fran&ccedil;ais</a> </li> 
+        <li data-language="it"> <a href="https://aws.amazon.com/it/?nc1=h_ls">Italiano</a> </li> 
+        <li data-language="pt"> <a href="https://aws.amazon.com/pt/?nc1=h_ls">Portugu&ecirc;s</a> </li> 
+       </ul> 
+      </div> 
+      <div class="lb-col lb-tiny-24 lb-mid-12"> 
+       <ul class="lb-txt-none lb-ul lb-list-style-none lb-tiny-ul-block"> 
+        <li data-language="vi"> <a href="https://aws.amazon.com/vi/?nc1=f_ls">Tiếng Việt</a> </li> 
+        <li data-language="tr"> <a href="https://aws.amazon.com/tr/?nc1=h_ls">T&uuml;rk&ccedil;e</a> </li> 
+        <li data-language="ru"> <a href="https://aws.amazon.com/ru/?nc1=h_ls">Ρусский</a> </li> 
+        <li data-language="th"> <a href="https://aws.amazon.com/th/?nc1=f_ls">ไทย</a> </li> 
+        <li data-language="jp"> <a href="https://aws.amazon.com/jp/?nc1=h_ls">日本語</a> </li> 
+        <li data-language="ko"> <a href="https://aws.amazon.com/ko/?nc1=h_ls">한국어</a> </li> 
+        <li data-language="cn"> <a href="https://aws.amazon.com/cn/?nc1=h_ls">中文 (简体)</a> </li> 
+        <li data-language="tw"> <a href="https://aws.amazon.com/tw/?nc1=h_ls">中文 (繁體)</a> </li> 
+       </ul> 
+      </div> 
+     </div> 
+    </div> 
+    <div class="lb-popover lb-popover-aui lb-popover-tiny" data-lb-comp="popover" data-id="popover-my-account" data-action="hover" data-position="top"> 
+     <ul class="lb-txt-none lb-ul lb-list-style-none lb-tiny-ul-block"> 
+      <li> <a href="https://console.aws.amazon.com/?nc2=h_m_mc">AWS Management Console</a> </li> 
+      <li> <a href="https://portal.aws.amazon.com/gp/aws/manageYourAccount?nc2=h_m_ma">Account Settings</a> </li> 
+      <li> <a href="https://console.aws.amazon.com/billing/home?nc2=h_m_bc">Billing &amp; Cost Management</a> </li> 
+      <li> <a href="https://console.aws.amazon.com/iam/home?nc2=h_m_sc#security_credential">Security Credentials</a> </li> 
+      <li> <a href="https://phd.aws.amazon.com/?nc2=h_m_sc">AWS Personal Health Dashboard</a> </li> 
+     </ul> 
+    </div> 
+    <div class="lb-popover lb-popover-aui lb-popover-tiny" data-lb-comp="popover" data-id="popover-support-selector" data-action="hover" data-position="top"> 
+     <ul class="lb-txt-none lb-ul lb-list-style-none lb-tiny-ul-block"> 
+      <li> <a href="https://console.aws.amazon.com/support/home/?nc2=h_ql_cu">Support Center</a> </li> 
+      <li> <a href="/premiumsupport/knowledge-center/?nc2=h_m_ma">Knowledge Center</a> </li> 
+      <li> <a href="/premiumsupport/?nc2=h_m_bc">AWS Support Overview</a> </li> 
+     </ul> 
+    </div> 
+    <script class="tt-suggestion-tpl" type="text/x-handlebars-template">
+    <div>
+      <a href="{{primaryUrl}}">
+        <div class="tt-title">
+          {{title}}
+        </div>
+        {{#if desc}}
+          <div class="tt-desc">
+            {{desc}}
+          </div>
+        {{/if}}
+      </a>
+      <div class="tt-btn-group">
+        {{#if pricingUrl}}
+          <a href="{{pricingUrl}}">
+            <div class="tt-btn">Pricing</div>
+          </a>
+        {{/if}}
+        {{#if docsUrl}}
+          <a href="{{docsUrl}}">
+            <div class="tt-btn">Documentation</div>
+          </a>
+        {{/if}}
+      </div>
+    </div>
+  </script> 
+    <script class="tt-products-head-tpl" type="text/x-handlebars-template">
+    <div class="tt-header lb-txt-bold">
+      <p>Products</p>
+    </div>
+  </script> 
+    <script class="tt-keypages-head-tpl" type="text/x-handlebars-template">
+    <div class="tt-header lb-txt-bold">
+      <p>Related Pages</p>
+    </div>
+  </script> 
+    <script class="tt-tutorials-head-tpl" type="text/x-handlebars-template">
+    <div class="tt-header lb-txt-bold">
+      <p>Tutorials</p>
+    </div>
+  </script> 
+    <script class="tt-blogs-head-tpl" type="text/x-handlebars-template">
+    <div class="tt-header lb-txt-bold">
+      <p>Blogs</p>
+    </div>
+  </script> 
+    <script class="tt-see-all-tpl" type="text/x-handlebars-template">
+    <div class="tt-see-all">
+      <a href="https://aws.amazon.com/search/?searchQuery={{ query }}">See more results for "{{ query }}"&lrm;</a>
+    </div>
+  </script> 
+   </div> 
+   <div id="m-nav-mobile" class="m-nav-mobile"> 
+    <div id="m-nav-mobile-header" class="m-nav-mobile-header" data-menu-url="https://s0.awsstatic.com/en_US/nav/v3/panel-content/mobile/index.html"> 
+     <div class="lb-bg-logo aws-amazon_web_services_smile-header-mobile-en"> 
+      <a href="https://aws.amazon.com/?nc2=h_lg"><span>Click here to return to Amazon Web Services homepage</span></a> 
+     </div> 
+     <div class="m-nav-mobile-button-group"> 
+      <i class="m-nav-mobile-button icon-search"></i> 
+      <i class="m-nav-mobile-button icon-reorder"></i> 
+     </div> 
+    </div> 
+    <div id="m-nav-mobile-search" class="m-nav-mobile-search"> 
+     <form action="https://aws.amazon.com/search" role="search"> 
+      <div class="m-typeahead"> 
+       <input class="m-nav-search-field" placeholder="Search" autocomplete="off" spellcheck="false" dir="auto" type="text" name="searchQuery" /> 
+      </div> 
+     </form> 
+    </div> 
+    <nav id="m-nav-trimdown" role="navigation"> 
+     <ul class="m-nav-mobile-menu-group"> 
+      <li> <a href="/products/?nc2=h_mo">Products</a> </li> 
+      <li> <a href="/solutions/?nc2=h_mo">Solutions</a> </li> 
+      <li> <a href="/pricing/?nc2=h_mo">Pricing</a> </li> 
+      <li> <a href="/what-is-aws/?nc2=h_mo">Introduction to AWS</a> </li> 
+      <li> <a href="/getting-started/?nc2=h_mo">Getting Started</a> </li> 
+      <li> <a href="/documentation/?nc2=h_mo">Documentation</a> </li> 
+      <li> <a href="/training/?nc2=h_mo">Training and Certification</a> </li> 
+      <li> <a href="/developer/?nc2=h_mo">Developer Center</a> </li> 
+      <li> <a href="/solutions/case-studies/?nc2=h_mo">Customer Success</a> </li> 
+      <li> <a href="/partners/?nc2=h_mo">Partner Network</a> </li> 
+      <li> <a href="https://aws.amazon.com/marketplace/?nc2=h_mo">AWS Marketplace</a> </li> 
+      <li> <a href="https://console.aws.amazon.com/support/home?nc2=h_ql_cu">Support</a> </li> 
+      <li> <a href="https://console.aws.amazon.com/console/home">Log into Console</a> </li> 
+      <li> <a href="/console/mobile/">Download the Mobile App</a> </li> 
+     </ul> 
+    </nav> 
+   </div> 
+  </header> 
+  <div id="aws-page-content" class="page-content"> 
+   <div class="wrapper row"> 
+    <aside class="three columns leftnavcontainer" role="complementary"> 
+     <div class="leftnav"> 
+      <div class="sidebar parsys iparsys"> 
+       <div class="section"> 
+        <div class="new"></div> 
+       </div> 
+       <div class="iparys_inherited"> 
+        <div class="sidebar parsys iparsys"> 
+         <div class="section"> 
+          <div class="anchor-link-list"> 
+           <nav> 
+            <div class="breadcrumb-wrapper clearfix"> 
+             <div class="breadcrumb"> 
+              <div class="small-logo-wrapper"> 
+               <a href="#top"> 
+                <div class="small-logo">
+                  Amazon Web Services 
+                </div></a> 
+              </div> 
+              <span class="breadcrumb-small"><a href="/about-aws/">ABOUT AWS</a></span> 
+             </div> 
+             <div class="go-to-top"> 
+              <a href="#top"><i class="icon-angle-up button"></i></a> 
+             </div> 
+            </div> 
+            <ul class="side-navbar nav"> 
+             <div class="custom-sidenavItem new_slide1 parbase"> 
+              <li class=""> <a class="link-list-item" href="/about-aws/"> About AWS<i class="icon-angle-right"></i> </a> </li> 
+             </div> 
+             <div class="custom-sidenavItem new_slide parbase"> 
+              <li class=""> <a class="link-list-item" href="/about-aws/global-infrastructure/"> Global Infrastructure<i class="icon-angle-right"></i> </a> </li> 
+             </div> 
+             <div class="custom-sidenavItem parbase new_slide_1"> 
+              <li class=""> <a class="link-list-item" href="/new/"> What's New<i class="icon-angle-right"></i> </a> </li> 
+             </div> 
+             <div class="custom-sidenavItem parbase new_slide_2"> 
+              <li class=""> <a class="link-list-item" href="/about-aws/in-the-news/"> AWS in the News<i class="icon-angle-right"></i> </a> </li> 
+             </div> 
+             <div class="custom-sidenavItem parbase new_slide_3"> 
+              <li class=""> <a class="link-list-item" href="/about-aws/events/"> Events &amp; Webinars<i class="icon-angle-right"></i> </a> </li> 
+             </div> 
+            </ul> 
+            <script>
+            require(["scripts"], function() {
+                var options = {
+                    scrollspy: true
+                };
+
+                $.awsComponent.leftSideBar(options);
+            });
+        </script> 
+           </nav> 
+          </div> 
+         </div> 
+         <div class="section"> 
+          <div class="related-link"> 
+           <p>Related Links</p> 
+           <ul> 
+            <li> <a class="related-item" href="/what-is-cloud-computing/"> What is Cloud Computing? </a> </li> 
+            <li> <a class="related-item" href="/free/"> AWS Free Usage Tier </a> </li> 
+            <li> <a class="related-item" href="http://aws.amazon.com/blogs/aws/"> AWS Blog </a> </li> 
+            <li> <a class="related-item" href="/careers/"> AWS Careers </a> </li> 
+            <li> <a class="related-item" href="/training/"> AWS Training </a> </li> 
+           </ul> 
+          </div> 
+         </div> 
+         <div class="section"> 
+          <div class="parbase mbox"> 
+           <div class="lb-mbox js-mbox" data-lb-comp="mbox" data-mbox="en_nav_left_cta" data-lb-comp-ignore="true"> 
+            <div class="parsys mbox"> 
+             <div class="call-to-action parbase section"> 
+              <div class="sidebar-cta "> 
+               <p>Get Started with AWS for Free</p> 
+               <a class="button btn-gold" href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html">Create Free Account</a> 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+          </div> 
+         </div> 
+        </div> 
+       </div> 
+      </div> 
+     </div> 
+    </aside> 
+    <div class="nine columns content-with-nav"> 
+     <main role="main"> 
+      <section data-page-alert-target="true"> 
+       <div class="title-wrapper"> 
+        <div class="row title"> 
+         <div class="twelve columns"> 
+          <h1 id="2020"> <a name="2020"> 2020</a> </h1> 
+         </div> 
+        </div> 
+       </div> 
+       <div class="parsys content"> 
+        <div class="parbase section list"> 
+         <div class=""> 
+          <ul class="directory-list whats-new-detail"> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-ecs-supports-tagging-task-sets/">Amazon ECS now Supports tagging for Task Sets </a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Elastic Container Service now enables customers to tag Task Sets when deploying an ECS service that uses the EXTERNAL deployment controller type. This will enable ECS customers to improve visibility into workloads, easily search and identify containerized applications, implement programmatic infrastructure management actions, and define fine-grained resource-level permissions.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-ecs-supports-tagging-task-sets/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-rds-performance-insights-supports-sql-level-metrics-mariadb/">Amazon RDS Performance Insights Supports SQL-level Metrics on Amazon RDS for MariaDB</a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon RDS Performance Insights supports SQL-level metrics on Amazon RDS for MariaDB so you can identify high-frequency, long-running, and stuck SQL queries in seconds.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-rds-performance-insights-supports-sql-level-metrics-mariadb/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-mq-now-available-in-asia-pacific-hong-kong-middle-east-bahrain-regions/">Amazon MQ is Now Available in Asia Pacific (Hong Kong), and Middle East (Bahrain) regions</a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon MQ is now available in a total of 18 regions, with the addition of the Asia Pacific (Hong Kong), and Middle East (Bahrain) regions. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-mq-now-available-in-asia-pacific-hong-kong-middle-east-bahrain-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-vpc-flow-logs-support-1-min-aggregation-intervals/">Amazon VPC Flow Logs Now Support 1-minute Aggregation Intervals</a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now capture and aggregate your Amazon Virtual Private Cloud (Amazon VPC) flow logs at shorter intervals of up to 1 minute, giving you quicker visibility into your network traffic flows. With a 1-minute configuration, your VPC flow logs arrive in an expedited manner and provide more granular visibility into the sequence of events in a flow, thereby enabling you to accurately investigate and rapidly respond to security incidents, or troubleshoot connectivity issues faster.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-vpc-flow-logs-support-1-min-aggregation-intervals/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-cognito-user-pools-now-supports-logging-for-all-api-calls-with-aws-cloudtrail/">Amazon Cognito User Pools service now supports logging for all API calls with AWS CloudTrail </a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Cognito User Pools&nbsp;now supports logging for all of the actions listed on the <a href="https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_Operations.html" target="_blank">User Pool Actions page</a> as events in CloudTrail log files, making it easier for developers to record all actions taken by a user, role, or an AWS service. The enhanced CloudTrail logging improves governance, compliance, and operational and risk auditing capabilities. Hosted UI and Federation calls are currently not included in CloudTrail logging events. Developers can create a trail and enable continuous delivery of Cognito API calls captured as CloudTrail events to an Amazon S3 bucket. Without configuring a trail, developers can still view the most recent events in the CloudTrail console in the Event history. This feature is available now in Amazon Cognito User Pools at no additional cost. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-cognito-user-pools-now-supports-logging-for-all-api-calls-with-aws-cloudtrail/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-elastic-file-system-amazon-efs-is-now-available-in-the-aws-govcloud-us-east-region/">Amazon Elastic File System (Amazon EFS) is now available in the AWS GovCloud (US-East) Region</a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Elastic File System (Amazon EFS) is now available in the&nbsp;<a href="/govcloud-us/">AWS GovCloud (US-East) Region</a>. With this launch, Amazon EFS is now available in all standard AWS Regions.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-elastic-file-system-amazon-efs-is-now-available-in-the-aws-govcloud-us-east-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-rds-performance-insights-supports-sql-level-metrics-on-amazon-rds-for-mysql/">Amazon RDS Performance Insights Supports SQL-level Metrics on Amazon RDS for MySQL</a></h3> 
+            <div class="date">
+              Posted On: Feb 5, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon RDS Performance Insights supports SQL-level metrics on Amazon RDS for MySQL databases so you can identify high-frequency, long-running, and stuck SQL queries in seconds.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-rds-performance-insights-supports-sql-level-metrics-on-amazon-rds-for-mysql/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-redshift-supports-per-second-billing/">Amazon Redshift now supports per-second billing</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Starting today, Redshift will be billed in one-second increments for on-demand clusters. Pricing is still listed on a per-hour basis, but bills are now calculated down to the second and show usage in decimal form. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-redshift-supports-per-second-billing/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-storage-gateway-available-linux-kvm-hypervisor/">AWS Storage Gateway is now available on Linux KVM hypervisor</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>The <a href="/storagegateway/">AWS Storage Gateway</a> service now includes the Linux Kernel-based Virtual Machine (KVM) hypervisor as a deployment option for all gateway types. If you use KVM hypervisor-based on-premises infrastructure, you can now deploy Storage Gateway in your environment to access virtually unlimited cloud storage.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-storage-gateway-available-linux-kvm-hypervisor/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/cloud9-launches-support-for-tagging-new-and-existing-environments/">Cloud9 launches support for tagging new and existing environments</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Cloud9 now supports the ability to tag Cloud9 development environments through both the console and the AWS API. Further documentation about tags is available <a href="https://docs.aws.amazon.com/cloud9/latest/user-guide/tags.html" target="_blank">here</a>.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/cloud9-launches-support-for-tagging-new-and-existing-environments/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-trusted-advisor-expands-to-new-regions-and-updates-existing-checks/">AWS Trusted Advisor expands to new regions and updates existing checks</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/premiumsupport/technology/trusted-advisor/" target="_blank">AWS Trusted Advisor</a> is an application that draws upon best practices learned from AWS’ aggregated operational history of serving millions of AWS customers. Trusted Advisor inspects your AWS environment and makes recommendations for saving money, improving system performance, and closing security gaps.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-trusted-advisor-expands-to-new-regions-and-updates-existing-checks/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-ebs-fast-snapshot-restore-expands-availability-to-all-commercial-regions-increases-limit-on-snapshots/">Amazon EBS increases limits on Fast Snapshot Restore and expands availability to additional regions</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Starting today, <a href="/ebs/" target="_blank">Amazon EBS</a>&nbsp;Fast Snapshot Restore (FSR) is available in all AWS commercial regions excluding China and AWS GovCloud regions. Additionally, the limits for FSR-enabled snapshots per region are increased from 5 to 50.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-ebs-fast-snapshot-restore-expands-availability-to-all-commercial-regions-increases-limit-on-snapshots/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-polly-launches-brand-voice/">Amazon Polly Launches Brand Voice</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/polly/">Amazon Polly</a> is a service that turns text into lifelike speech, and offers over 60 publicly available voices in 29 languages. AWS is excited to announce a new feature in Amazon Polly called Brand Voice, a feature where customers can engage the Amazon Polly team to build custom high-quality Neural Text-to-Speech (NTTS) voices that represent the customer’s brand persona. Polly’s Brand Voices are created for the exclusive use of the customer, allowing them to differentiate themselves by incorporating a unique vocal identity into the products and services that they offer to their end users.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-polly-launches-brand-voice/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-robomaker-supports-sudo-access-inside-robot-and-simulation-applications-at-runtime/">AWS RoboMaker supports sudo access inside robot and simulation applications at runtime</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS RoboMaker announces the support for sudo access inside robot and simulation applications at runtime. Customers now have additional flexibility to modify their robot and simulation application environment at runtime so as to align with the environment they have on their robot. With sudo access, customers can install custom software, make changes to the root filesystem, update file permissions, and troubleshoot issues. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-robomaker-supports-sudo-access-inside-robot-and-simulation-applications-at-runtime/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-translate-is-now-fedramp-compliant/">Amazon Translate is now FedRAMP compliant </a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/translate/" target="_blank">Amazon Translate</a> –&nbsp;a fully managed neural machine translation service that delivers high-quality, and affordable language translation in fifty-four languages and seventeen regions – has been added to the list of <a href="/compliance/services-in-scope/" target="_blank">AWS Services in Scope</a> for the Federal Risk and Authorization Management Program (FedRAMP) High baseline. Amazon Translate is also included on the list of AWS Services in Scope for the FedRAMP Moderate baseline. Additional information and resources regarding FedRAMP and AWS are <a href="/compliance/fedramp/" target="_blank">available here</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/amazon-translate-is-now-fedramp-compliant/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-compute-optimizer-available-in-11-additional-regions/">AWS Compute Optimizer Available In 11 Additional Regions</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-compute-optimizer-available-in-11-additional-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-config-now-supports-multi-account-multi-region-aggregation-in-aws-govcloud-us-regions/">AWS Config now supports multi-account, multi-region aggregation in AWS GovCloud (US) Regions</a></h3> 
+            <div class="date">
+              Posted On: Feb 4, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Config now supports <a href="https://docs.aws.amazon.com/config/latest/developerguide/aggregate-data.html">multi-account, multi-region data aggregation</a> capability in <a href="/govcloud-us/">AWS GovCloud (US)</a>. This feature enables you to aggregate resource configuration and Config rule compliance data into a single account and Region, which reduces the time and overhead needed to gather an enterprise-wide view of your resource inventory and compliance status for governance. The data aggregation capability is also integrated with AWS Organizations, so you can centrally retrieve this data for any account within your organization. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/02/aws-config-now-supports-multi-account-multi-region-aggregation-in-aws-govcloud-us-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-is-now-available-for-amazon-elastic-file-system-efs-in-4-additional-regions/">AWS Backup is now available for Amazon Elastic File System (Amazon EFS) in 4 additional regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 31, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Backup is now available to protect Amazon Elastic File System (Amazon EFS) workloads in four more regions across Asia Pacific, Europe / Middle East / Africa (EMEA), and the Americas. These regions include: Asia Pacific (Hong Kong),EU (Stockholm), Middle East (Bahrain), and South America (S&atilde;o Paulo).<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-is-now-available-for-amazon-elastic-file-system-efs-in-4-additional-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-managed-cassandra-service-now-supports-ordering-clauses-in-cql-queries-and-aws-cloudtrail-logging/">Amazon Managed Cassandra Service now supports ordering clauses in CQL queries and AWS CloudTrail logging</a></h3> 
+            <div class="date">
+              Posted On: Jan 30, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="https://aws.amazon.com/mcs/" target="_blank">Amazon Managed Apache Cassandra Service (MCS)</a>, a scalable, highly available, and managed Apache Cassandra–compatible database service, now supports ordering clauses in Cassandra Query Language (CQL) queries and <a href="https://aws.amazon.com/cloudtrail/" target="_blank">AWS CloudTrail</a> logging for control-plane operations.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-managed-cassandra-service-now-supports-ordering-clauses-in-cql-queries-and-aws-cloudtrail-logging/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-batch-now-available-in-aws-govcloud-us-regions/">AWS Batch now available in AWS GovCloud (US) Regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 30, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Starting today, AWS Batch is available in the <a href="https://aws.amazon.com/govcloud-us/">AWS GovCloud (US)</a> Regions. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-batch-now-available-in-aws-govcloud-us-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-architecting-serverless-solutions/">New Digital Course: Architecting Serverless Solutions</a></h3> 
+            <div class="date">
+              Posted On: Jan 28, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Learn to “think serverless” with this free training course from AWS. In this intermediate, three-hour digital course, you will learn how to combine AWS Lambda and Amazon API Gateway in event-driven patterns to power scalable and secure serverless applications.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-architecting-serverless-solutions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-aws-transit-gateway-networking-and-scaling/">New Digital Course: AWS Transit Gateway Networking and Scaling </a></h3> 
+            <div class="date">
+              Posted On: Jan 28, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We’re excited to announce a free training course that demonstrates how to create and configure an AWS Transit Gateway. In this digital course, you will learn about setting up a basic Transit Gateway, creating a Transit Gateway with shared domains and route tables, and routing and propagation. Demonstrations will help teach you about connecting VPN and direct connect to AWS Transit Gateway.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-aws-transit-gateway-networking-and-scaling/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-certificate-manager-private-certificate-authority-offers-cloudformation-resources/">AWS Certificate Manager Private Certificate Authority Now Offers CloudFormation Resources</a></h3> 
+            <div class="date">
+              Posted On: Jan 27, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Certificate Manager (ACM) Private Certificate Authority (CA) now offers Amazon CloudFormation resources. You can create templates for the service or application architectures you want and have AWS CloudFormation use those templates for quick and reliable provisioning of the services or applications (called “stacks”). You can also easily update or replicate the stacks as needed. For example, you can use CloudFormation to build and activate an issuing CA and then issue a private certificate from that CA. This feature offers templates for CAs, CA activation and private certificates.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-certificate-manager-private-certificate-authority-offers-cloudformation-resources/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-opsworks-for-chef-automate-now-supports-in-place-upgrade-to-chef-automate-2/">AWS OpsWorks for Chef Automate Now Supports In-Place Upgrade to Chef Automate 2</a></h3> 
+            <div class="date">
+              Posted On: Jan 27, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now perform an in-place upgrade of your Chef Automate server to Chef Automate 2 from the AWS OpsWorks for Chef Automate console or the AWS CLI.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-opsworks-for-chef-automate-now-supports-in-place-upgrade-to-chef-automate-2/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-forecast-now-available-in-seoul-asia-pacific-region/">Amazon Forecast now available in Seoul (Asia Pacific) region</a></h3> 
+            <div class="date">
+              Posted On: Jan 27, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/forecast/">Amazon Forecast</a> is now available in the Seoul (Asia Pacific) region. Amazon Forecast is a fully managed service that uses machine learning (ML) to generate accurate forecasts, without requiring any prior ML experience. Amazon Forecast is applicable in a wide variety of use cases, including inventory planning, energy demand forecasting, financial planning, workforce planning, cloud infrastructure usage forecasting, and traffic forecasting.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-forecast-now-available-in-seoul-asia-pacific-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ec2-t3-instances-support-launching-dedicated-instances/">Amazon EC2 T3 instances now support launching as Dedicated Instances</a></h3> 
+            <div class="date">
+              Posted On: Jan 24, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/ec2/instance-types/t3/">Amazon EC2 T3 instances</a> are now available to launch as dedicated instances. T3 instances are a low cost burstable general-purpose instance type that provide a baseline level of CPU performance with the ability to burst CPU usage at any time for as long as required. T3 instances are designed for applications with moderate CPU usage that experience temporary spikes in use. T3 dedicated instances run in a VPC on hardware that's dedicated to a single customer. This means that your T3 dedicated instances will be physically isolated at the host hardware level from instances that belong to other AWS accounts. Dedicated instances may help customers meet their specific compliance goals or run software with specific licensing restrictions. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ec2-t3-instances-support-launching-dedicated-instances/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-datasync-transfer-data-to-and-from-amazon-fsx-windows-file-server/">AWS DataSync can now transfer data to and from Amazon FSx for Windows File Server</a></h3> 
+            <div class="date">
+              Posted On: Jan 24, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/datasync/">AWS DataSync</a> now supports transferring files to and from <a href="/fsx/windows/">Amazon FSx for Windows File Server</a>, providing you with a simple and automated way to accelerate the migration of your self-managed file systems to fully managed native Microsoft Windows file systems in AWS. With this new capability you can easily and securely transfer datasets containing hundreds of terabytes and millions of files to Amazon FSx for Windows File Server. This simplifies and accelerates the migration of home directories and Windows-based workloads that require file storage, such as CRM, ERP, and .NET applications. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-datasync-transfer-data-to-and-from-amazon-fsx-windows-file-server/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-cloud-map-supports-editing-custom-service-instance-attributes-in-the-aws-console/">AWS Cloud Map supports editing custom service instance attributes in the AWS Console</a></h3> 
+            <div class="date">
+              Posted On: Jan 24, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Cloud Map now allows you to view service instance details and edit custom service instance attributes in the AWS Console. This feature, which was previously available only through the AWS CLI, SDK, or API, provides better visibility into the composition of your services and simplifies updating the metadata associated with cloud resources registered in AWS Cloud Map.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-cloud-map-supports-editing-custom-service-instance-attributes-in-the-aws-console/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elemental-mediaconnect-now-available-in-asia-pacific-hong-kong-region/">AWS Elemental MediaConnect Now Available in Asia Pacific (Hong Kong) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 24, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/mediaconnect/">AWS Elemental MediaConnect</a> is now available in the Asia Pacific (Hong Kong) region. Using MediaConnect, you can now ingest, transport, and process your high-quality video in the AWS Cloud in more locations globally.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elemental-mediaconnect-now-available-in-asia-pacific-hong-kong-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-guardduty-announces-threat-detection-enhancements/">Amazon GuardDuty announces threat detection enhancements, reducing alert volume and increasing accuracy for common customer deployed architectures</a></h3> 
+            <div class="date">
+              Posted On: Jan 24, 2020 
+            </div> 
+            <div class="description"> 
+             <p>This month, Amazon GuardDuty launched enhancements to several existing threat detections that will result in many customers seeing a 50% reduction in findings generated for port probes, SSH brute force attempts, and indications of DNS data exfiltration. These enhancements are now included in Amazon GuardDuty across all supported AWS regions globally. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-guardduty-announces-threat-detection-enhancements/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-msk-now-available-bahrain/">Amazon MSK is now available in Middle East (Bahrain) </a></h3> 
+            <div class="date">
+              Posted On: Jan 23, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now connect your Apache Kafka applications to <a href="/msk/" target="_blank">Amazon MSK</a> in the Middle East (Bahrain) <a href="/about-aws/global-infrastructure/regional-product-services/" target="_blank">AWS Region</a>. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-msk-now-available-bahrain/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/announcing-amazon-relational-database-service-snapshot-export-to-s3/">Announcing Amazon Relational Database Service (RDS) Snapshot Export to S3 </a></h3> 
+            <div class="date">
+              Posted On: Jan 23, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now export <a href="/rds/" target="_blank">Amazon Relational Database Service</a> (Amazon RDS) or <a href="/rds/aurora/" target="_blank">Amazon Aurora</a> snapshots to <a href="/s3/" target="_blank">Amazon S3</a> as <a href="https://parquet.apache.org/" target="_blank">Apache Parquet</a>, an efficient open columnar storage format for analytics. The Parquet format is up to 2x faster to export and consumes up to 6x less storage in Amazon S3, compared to text formats. You can analyze the exported data with other AWS services such as Amazon Athena, Amazon EMR, and Amazon SageMaker.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/announcing-amazon-relational-database-service-snapshot-export-to-s3/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/deep-learning-containers-updates-sagemaker-debugger-tensorflow-serving/">Deep Learning Containers Updates for SageMaker Debugger and Tensorflow Serving</a></h3> 
+            <div class="date">
+              Posted On: Jan 23, 2020 
+            </div> 
+            <div class="description"> 
+             <p>The <a href="/machine-learning/containers/">AWS Deep Learning Containers</a> are available today with bug fixes to the SageMaker integration with Tensorflow Server and the latest version of SageMaker Debugger. You can launch the new versions of Deep Learning Container on Amazon SageMaker, Amazon Elastic Kubernetes Service (Amazon EKS), self-managed Kubernetes on Amazon EC2, and Amazon Elastic Container Service (Amazon ECS). For a complete list of frameworks and versions supported by the AWS Deep Learning Containers, see <a href="https://aws.amazon.com/releasenotes/?tag=releasenotes#keywords#aws-deep-learning-containers">release notes</a>.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/deep-learning-containers-updates-sagemaker-debugger-tensorflow-serving/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-adds-support-for-windows-server-2019-and-net-core-3-1/">AWS Elastic Beanstalk adds support for Windows Server 2019 and .NET Core 3.1</a></h3> 
+            <div class="date">
+              Posted On: Jan 23, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Elastic Beanstalk now supports <a href="https://www.microsoft.com/en-us/cloud-platform/windows-server">Windows Server 2019</a>, Windows Server Core 2019, and .NET Core 3.1. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-adds-support-for-windows-server-2019-and-net-core-3-1/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-iam-policy-simulator-now-simulates-permissions-boundary-policies/">AWS IAM policy simulator now simulates permissions boundary policies</a></h3> 
+            <div class="date">
+              Posted On: Jan 23, 2020 
+            </div> 
+            <div class="description"> 
+             <p>With the AWS Identity and Access Management (IAM) policy simulator, administrators can now simulate <a href="/blogs/security/delegate-permission-management-to-developers-using-iam-permissions-boundaries/">permissions boundary policies</a> along with other permissions policies to better understand the effective permissions for IAM principals (users and roles) in their AWS environment. Additionally, developers can now use the policy simulator to debug issues related to permissions boundary policies.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-iam-policy-simulator-now-simulates-permissions-boundary-policies/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-mq-supports-activemq-version-5-15-10/">Amazon MQ now supports ActiveMQ Version 5.15.10</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now launch Apache ActiveMQ 5.15.10 brokers on Amazon MQ. This patch update to ActiveMQ contains several fixes and new features compared to the previously supported version, ActiveMQ 5.15.9.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-mq-supports-activemq-version-5-15-10/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-auto-scaling-available-aws-govcloud-regions/">AWS Auto Scaling now available in AWS GovCloud (US) Regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Auto Scaling is now available in <a href="/govcloud-us/">AWS GovCloud (US) Regions</a>. AWS GovCloud (US) customers can now use AWS Auto Scaling to manage dynamic scaling configuration for multiple resources such as Amazon EC2 instances, Amazon ECS tasks, Amazon DynamoDB tables and indexes, and Amazon Aurora read replicas with a single scaling plan.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-auto-scaling-available-aws-govcloud-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-rds-for-mysql-supports-authentication-with-active-directory/">Amazon RDS for MySQL Supports Authentication with Active Directory</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/rds/mysql/" target="_blank">Amazon RDS for MySQL</a> now supports authentication of database users using <a href="https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_getting_started.html" target="_blank">AWS Managed Microsoft Active Directory Service</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-rds-for-mysql-supports-authentication-with-active-directory/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-efs-available-in-aws-china/">Amazon Elastic File System (Amazon EFS) is now available in the AWS China (Beijing) Region, operated by Sinnet, and AWS China (Ningxia) Region, operated by NWCD</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Elastic File System (Amazon EFS) is now available in the AWS China (Ningxia) Region, operated by NWCD and the AWS China (Beijing) Region, operated by Sinnet.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-efs-available-in-aws-china/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/quick-start-update-hashicorp-consul-on-the-aws-cloud/">Quick Start Update: HashiCorp Consul on the AWS Cloud</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p>HashiCorp and AWS are pleased to release a major update to the HashiCorp Consul Quick Start, which deploys HashiCorp Consul on the Amazon Web Services (AWS) Cloud. HashiCorp Consul is a tool that provides a foundation for cloud networking automation by using a central registry for service-based networking.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/quick-start-update-hashicorp-consul-on-the-aws-cloud/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-control-tower-introduces-lifecycle-event-notifications/">AWS Control Tower introduces lifecycle event notifications</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/controltower/" target="_blank">AWS Control Tower</a>&nbsp;announces the availability of lifecycle event notifications. A lifecycle event marks the completion of a Control Tower action that can change the state of resources such as organizational units (OUs), accounts and guardrails that are created and managed by Control Tower. Lifecycle events are recorded as AWS CloudTrail events and delivered to Amazon EventBridge as events, and the event log states if the Control Tower action completed successfully or not. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-control-tower-introduces-lifecycle-event-notifications/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ebs-direct-apis-for-snapshots-now-available-in-ten-additional-regions/">Amazon EBS direct APIs for Snapshots Now Available in Ten Additional Regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 22, 2020 
+            </div> 
+            <div class="description"> 
+             <p>EBS direct APIs for Snapshots are now available in ten additional regions: US East (Ohio), US West (N. California), Canada (Central), Europe (London), Europe (Stockholm), Europe (Paris), Asia Pacific (Mumbai), Asia Pacific (Seoul), Asia Pacific (Sydney), and South America (S&atilde;o Paulo).<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ebs-direct-apis-for-snapshots-now-available-in-ten-additional-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-aws-public-datasets-available-from-ford-nasa-nrel/">New AWS Public Datasets Available from Ford, NASA, and NREL</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>6 new AWS Public Datasets are now available in the following categories:&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-aws-public-datasets-available-from-ford-nasa-nrel/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-eks-announces-price-reduction/">Amazon EKS Announces a 50% Price Reduction </a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Today, we’re reducing the price for Amazon Elastic Kubernetes Service (EKS) by 50% to $0.10 per hour for each Kubernetes cluster that you run. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-eks-announces-price-reduction/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-neptune-provides-data-base-deletion-protection/">Amazon Neptune provides database deletion protection</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now enable deletion protection for your <a href="https://aws.amazon.com/neptune">Amazon Neptune</a> database clusters. When a database cluster is configured with deletion protection, the database cannot be deleted by any user.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-neptune-provides-data-base-deletion-protection/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-vpc-ingress-routing-now-supports-aws-cloudformation/">Amazon VPC Ingress Routing Now Supports AWS CloudFormation</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now create AWS CloudFormation templates to provision and configure Amazon Virtual Private Cloud (Amazon VPC) ingress routing infrastructures predictably and repeatedly. Amazon VPC ingress routing allows you to route ingress and egress traffic to and from internet gateways and virtual private gateways through networking and security virtual appliances in your VPCs.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-vpc-ingress-routing-now-supports-aws-cloudformation/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-iot-greengrass-core-sdk-node-js-supports-greengrass-stream-manager/">AWS IoT Greengrass Core SDK for Node.js (v1.6.0) now supports Greengrass Stream Manager</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS IoT Greengrass released an AWS IoT Greengrass Core SDK for Node.js v1.6.0, which provides support for Greengrass Stream Manager. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-iot-greengrass-core-sdk-node-js-supports-greengrass-stream-manager/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-outposts-now-available-in-seven-new-regions-additional-countries/">AWS Outposts is now available in seven new regions and additional countries</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Outposts is now available in the following seven new regions:<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-outposts-now-available-in-seven-new-regions-additional-countries/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-cloudwatch-synthetics-available-13-additional-regions/">Amazon CloudWatch Synthetics is now available in 13 additional regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon CloudWatch Synthetics is now available in 13 additional regions - US West (Oregon), US West (N. California), EU (Frankfurt), EU (London), EU (Paris), EU (Stockholm), Canada (Central), Asia Pacific (Tokyo), Asia Pacific (Seoul), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Mumbai), and South America (Sao Paulo). Amazon CloudWatch Synthetics enables you to create canaries to monitor your endpoints and APIs.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-cloudwatch-synthetics-available-13-additional-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-on-edx-building-containerized-applications-on-aws/">New Digital Course on edX: Building Containerized Applications on AWS </a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We’re excited to announce the launch of <a href="https://www.edx.org/course/building-containerized-applications-on-aws" target="_blank">Building Containerized Applications on AWS</a>, a new self-paced digital course available exclusively on edX. Using video lectures, hands-on exercise guides, demonstrations, and quizzes, the course explains what containers are, as well as the differences between containers and virtual machines. It also covers how to use AWS services to build and deploy microservices-based applications, and which AWS services to use to simplify container management.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-digital-course-on-edx-building-containerized-applications-on-aws/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-classroom-planning-and-designing-databases-on-aws/">New Classroom Course: Planning and Designing Databases on AWS</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We are excited to announce the launch of <i>Planning and Designing Databases on AWS</i>, a new three-day, instructor-led classroom course.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-classroom-planning-and-designing-databases-on-aws/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/announcing-the-aws-game-tech-starter-pack-digital-training-curriculum/">Announcing the AWS Game Tech Starter Pack Digital Training Curriculum</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We’re excited to announce the launch of the new <i>AWS Game Tech Starter Pack</i>.&nbsp;This digital training curriculum covers key features of Amazon GameLift and Amazon Lumberyard, as well as how AWS analytics solutions, such as Amazon Kinesis and Amazon EMR, can lead to insights to solve real-world problems with games. The curriculum features four courses: <i>Amazon GameLift Primer</i>, <i>Amazon Lumberyard Primer</i>, <i>Data Analytics Fundamentals</i>, and <i>Why Analytics for Games</i>. They feature a combined eight hours of digital video content intended for back-end game developers, operation engineers, architects, designers, producers, artists, data scientists, analysts, and business leaders.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/announcing-the-aws-game-tech-starter-pack-digital-training-curriculum/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-key-management-service-expands-support-for-asymmetric-keys/">AWS Key Management Service expands support for asymmetric keys </a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Key Management Service (KMS) now enables customers to create asymmetric customer master keys (CMKs) and generate data key pairs in all regions where <a href="/about-aws/global-infrastructure/regional-product-services/" target="_blank">AWS KMS is available</a>, except in the AWS China (Beijing) Region, operated by Sinnet and the AWS China (Ningxia) Region, operated by NWCD. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-key-management-service-expands-support-for-asymmetric-keys/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-sagemaker-supports-tensorflow-2-0/">Amazon SageMaker Now Supports TensorFlow 2.0</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/sagemaker/">Amazon SageMaker</a> now supports Tensorflow 2.0 as a pre-built deep learning container. This latest version provides significant updates to the existing API, simplifies eager execution, offers a new dataset manager, and more. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-sagemaker-supports-tensorflow-2-0/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/query-volume-metrics-now-available-for-amazon-route-53-resolver-endpoints/">Query Volume Metrics Now Available for Amazon Route 53 Resolver Endpoints</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now use Amazon CloudWatch to see query volume metrics for Amazon Route 53 Resolver endpoints, including the aggregate number of queries that are handled by an outbound Resolver endpoint. This aggregate metric combines query counts from all accounts that are using shared conditional forwarding rules associated with the outbound Resolver endpoint. Additionally, you can view query volume metrics for each IP address that is associated with an inbound or outbound Resolver endpoint. This gives you an even more granular view of how query traffic is flowing amongst the IP addresses that are associated with a given Resolver endpoint. With these metrics, you can see at a glance the activity level for inbound and outbound queries going to and coming from your on-premises networks.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/query-volume-metrics-now-available-for-amazon-route-53-resolver-endpoints/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-personalize-now-available-seoul/">Amazon Personalize is now available in Asia Pacific (Seoul)</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/personalize/" target="_blank">Amazon Personalize</a> is now available in Asia Pacific (Seoul) region. Amazon Personalize is a machine learning service which enables you to personalize your website, app, ads, emails, and more, with custom machine learning models which can be created in Amazon Personalize, with no prior machine learning experience. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-personalize-now-available-seoul/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-codepipeline-enables-stopping-pipeline-executions/">AWS CodePipeline Enables Stopping Pipeline Executions</a></h3> 
+            <div class="date">
+              Posted On: Jan 21, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now easily stop a pipeline execution in CodePipeline. Previously, you had to either (a) disable transitions between stages and wait for a new pipeline execution to supersede the current pipeline execution; or (b) wait for active action executions to time out. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-codepipeline-enables-stopping-pipeline-executions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-to-launch-standard-aws-region-in-osaka-in-early-2021/">AWS to Launch Standard AWS Region in Osaka in Early 2021</a></h3> 
+            <div class="date">
+              Posted On: Jan 20, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Today, AWS announced plans to open a full AWS Region in Osaka, Japan. Expected in early 2021, the Asia Pacific (Osaka) Region will be launched by expanding the existing AWS (Osaka) Local Region with the addition of two new Availability Zones and an increased service portfolio.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-to-launch-standard-aws-region-in-osaka-in-early-2021/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-announces-price-reduction-cloudendure-disaster-recovery/">AWS announces 80% price reduction for CloudEndure Disaster Recovery</a></h3> 
+            <div class="date">
+              Posted On: Jan 20, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Today, we are reducing the price of <a href="/cloudendure-disaster-recovery/">CloudEndure Disaster Recovery</a> by 80% to $0.028 per hour per server, or an estimated $20 per month per server. CloudEndure Disaster Recovery minimizes downtime and data loss by providing fast, reliable recovery of physical, virtual, and cloud-based servers to AWS.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-announces-price-reduction-cloudendure-disaster-recovery/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/mp3-audio-output-now-available-with-aws-elemental-mediaconvert/">MP3 Audio Output Now Available with AWS Elemental MediaConvert</a></h3> 
+            <div class="date">
+              Posted On: Jan 17, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/mediaconvert/" target="_blank">AWS Elemental MediaConvert</a>&nbsp;now offers expanded support for audio-only workflows with the ability to create MP3 audio files. With MediaConvert, you can easily produce MP3 audio for devices and services that use this format with a simple selection from the console. Create MP3 files in standalone audio conversion jobs, extracted from video files, or as supplementary outputs produced during the video transcoding process. To learn more about supported audio formats, please see the <a href="https://docs.aws.amazon.com/mediaconvert/latest/ug/supported-codecs-containers-audio-only.html" target="_blank">documentation pages</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/mp3-audio-output-now-available-with-aws-elemental-mediaconvert/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ecs-preview-support-for-efs-file-systems-now-available/">Amazon ECS Preview Support for EFS file systems Now Available</a></h3> 
+            <div class="date">
+              Posted On: Jan 17, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/ecs/">Amazon Elastic Container Service (ECS)</a> now supports Amazon Elastic Filesystem (EFS) filesystems in ECS task definitions (in preview). When using ECS task definitions compatible with the EC2 launch type, customers can add EFS filesystems to their task definitions. This enables persistent, shared storage to be defined and used at the task and container level in ECS.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ecs-preview-support-for-efs-file-systems-now-available/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-direct-connect-supports-aws-transit-gateway-for-bahrain-region/">AWS Direct Connect supports AWS Transit Gateway for AWS Middle East (Bahrain) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 17, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Direct Connect support for AWS Transit Gateway is now available in AWS AWS Middle East (Bahrain) region. With this feature, customers can connect thousands of Amazon Virtual Private Clouds (Amazon VPCs) in multiple AWS Regions to their on-premises networks using 1/2/5/10 Gbps AWS Direct Connect connections. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-direct-connect-supports-aws-transit-gateway-for-bahrain-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-data-lifecycle-manager-now-available-in-the-asia-pacific-hong-kong-and-middle-east-bahrain-region/">Amazon Data Lifecycle Manager Now Available in the Asia Pacific (Hong Kong) and Middle East (Bahrain) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 17, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Starting today, Amazon Data Lifecycle Manager (Amazon DLM) for EBS Snapshots is available in the Asia Pacific (Hong Kong) and Middle East (Bahrain) region. Amazon DLM provides a simple, automated way to back up data stored on Amazon EBS volumes. With this feature, you no longer have to rely on custom scripts to create and manage your EBS volume backups. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-data-lifecycle-manager-now-available-in-the-asia-pacific-hong-kong-and-middle-east-bahrain-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-health-enables-aggregation-of-health-events-across-aws-organizations/">AWS Health enables aggregation of health events across AWS Organizations</a></h3> 
+            <div class="date">
+              Posted On: Jan 17, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now centrally aggregate your AWS Health events from all accounts in your organization. <a href="/organizations/">AWS Organizations</a> enables you to centrally govern and manage across multiple AWS accounts. The new AWS Health Organizational View provides centralized and real-time access to all AWS Health events posted to individual accounts in your organization, including operational issues, scheduled maintenance, and account notifications. You can start using Organizational View today via the AWS Health API. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-health-enables-aggregation-of-health-events-across-aws-organizations/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-aurora-supports-the-read-committed-isolation-level-on-read-replicas/">Amazon Aurora Supports the READ COMMITTED Isolation Level on Read Replicas</a></h3> 
+            <div class="date">
+              Posted On: Jan 16, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/rds/aurora/">Amazon Aurora</a> with MySQL compatibility supports the ANSI READ COMMITTED isolation level on read replicas. This isolation level enables long-running queries on an Aurora read replica to execute without impacting the throughput of writes on the writer node.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-aurora-supports-the-read-committed-isolation-level-on-read-replicas/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-command-line-interface-now-open-source/">AWS Elastic Beanstalk Command Line Interface (EBCLI) is now open source</a></h3> 
+            <div class="date">
+              Posted On: Jan 16, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now access the source code of <a href="https://github.com/aws/aws-elastic-beanstalk-cli" target="_blank">AWS Elastic Beanstalk Command Line Interface (EBCLI) on Github</a>. You can contribute to the development of EBCLI by making suggestions, reporting issues, and submitting pull requests. Visit the <a href="https://github.com/aws/aws-elastic-beanstalk-cli" target="_blank">EBCLI source code in the Github repository</a> to find more details. For more information about the EB CLI, see <a href="https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3.html" target="_blank">Using the Elastic Beanstalk Command Line Interface (EB CLI)</a> in the AWS Elastic Beanstalk Developer Guide.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-command-line-interface-now-open-source/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-glue-adds-new-transforms-apache-spark-applications-datasets-amazon-s3/">AWS Glue adds new transforms (Purge, Transition and Merge) for Apache Spark applications to work with datasets in Amazon S3</a></h3> 
+            <div class="date">
+              Posted On: Jan 16, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Glue now supports three new transforms - Purge, Transition, Merge - that can help you extend your extract, transform, and load (ETL) logic in Apache Spark applications. You can use the Purge transform to remove files, partitions or tables, and quickly refine your datasets on S3. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-glue-adds-new-transforms-apache-spark-applications-datasets-amazon-s3/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-systems-manager-now-provides-flexible-reboot-options-for-patching/">AWS Systems Manager now provides flexible reboot options for patching</a></h3> 
+            <div class="date">
+              Posted On: Jan 16, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Patch Manager, a capability of AWS Systems Manager, now gives you the option to defer rebooting after patch installation to a later time. You can choose this option if you have applications or processes running on the instance that cannot be disrupted during the patching operation.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-systems-manager-now-provides-flexible-reboot-options-for-patching/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-client-vpn-now-supports-port-configuration/">AWS Client VPN now Supports Port Configuration</a></h3> 
+            <div class="date">
+              Posted On: Jan 16, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now configure your AWS Client VPN endpoint to use either the port 443 or the port 1194, with support for both TCP and UDP transmissions. New and existing endpoints are defaulted to use the port 443. However, you can now modify these endpoints to use the port 1194. If you cannot use the port 443, such as for security reasons, using the port 1194 gives you more flexibility.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-client-vpn-now-supports-port-configuration/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/r5-instance-family-now-available-in-sao-paulo/">R5 instance family is now available in the South America (Sao Paulo) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/elasticache/" target="_blank">Amazon ElastiCache</a> now offers R5 nodes, the next generation memory and performance optimized nodes to maximize network performance and CPU utilization in the South America (S&atilde;o Paulo) AWS Region. R5 nodes feature the AWS Nitro System, a combination of dedicated hardware and lightweight hypervisor that delivers nearly all of the compute and memory resources to the guest VMs.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/r5-instance-family-now-available-in-sao-paulo/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-connect-now-supports-amazon-lex-in-sydney-region/">Amazon Connect Now Supports Amazon Lex in the Asia Pacific (Sydney) AWS Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now use Amazon Lex chatbots in the Asia Pacific (Sydney) AWS region. Amazon Lex allows you to create intelligent conversational chatbots that turn your Amazon Connect contact flows into natural conversations. These can be used to automate high volume interactions without compromising customer experience. Customers connecting to your Amazon Connect contact center can interact with an Amazon Lex chatbot to perform tasks such as changing a password, requesting a balance on an account, or scheduling an appointment using natural conversational language. Customers can say things like “I need help with my device” instead of having to listen through and remember a list of options like 1 for sales, or 2 for appointments.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-connect-now-supports-amazon-lex-in-sydney-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-kinesis-data-analytics-now-available-hong-kong-bahrain/">Amazon Kinesis Data Analytics is now available in Asia Pacific (Hong Kong) and Middle East (Bahrain)</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/kinesis/data-analytics/" target="_blank">Amazon Kinesis Data Analytics</a> is now available in two additional AWS regions: Asia Pacific (Hong Kong) and Middle East (Bahrain). Amazon Kinesis Data Analytics is now available in seventeen AWS regions. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-kinesis-data-analytics-now-available-hong-kong-bahrain/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-security-hub-releases-ability-disable-specific-compliance-controls/">AWS Security Hub releases the ability to disable specific compliance controls</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/security-hub/">AWS Security Hub</a> now allows you to disable specific compliance controls, if they are not relevant for you. For example, if the control 2.3 from the CIS AWS Foundations Benchmark (“Ensure that the S3 bucket used to store CloudTrail logs is not publicly accessible”) is not relevant in a particular account or region because you have a centralized logging bucket set up in another account or region, you can disable that control either via the Security Hub console or via the API. Disabled controls are not counted against your compliance readiness score for that standard, and they have a mandatory field to explain why the control has been disabled. Disablement actions are logged to AWS CloudTrail. Security Hub’s documentation provides <a href="https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards.html#securityhub-controls-disable">specific examples</a> of controls that you may want to disable depending on your account setup. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-security-hub-releases-ability-disable-specific-compliance-controls/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-neptune-now-available-in-aws-china-ningxia-region-operated-by-nwcd/">Amazon Neptune is now available in AWS China (Ningxia) Region, Operated by NWCD</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Neptune is now available in AWS China (Ningxia) Region, Operated by NWCD. You can now create Neptune clusters using R5 instance types in this AWS Region for your graph applications.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-neptune-now-available-in-aws-china-ningxia-region-operated-by-nwcd/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-ibm-filenet-content-manager-on-aws/">New Quick Start deploys IBM FileNet Content Manager on AWS</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p>This Quick Start automatically deploys a production-ready instance of IBM FileNet Content Manager version 5.5.3 on the AWS Cloud into a virtual private cloud (VPC) that spans multiple Availability Zones.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-ibm-filenet-content-manager-on-aws/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-polly-launches-in-bah-and-hkg-region/">Amazon Polly launches in Middle East (BAH) and Asia Pacific (HKG) regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/polly/">Amazon Polly</a> is a service that turns text into lifelike speech. Today, we are excited to announce the general availability of Amazon Polly standard voices in the Middle East (BAH) and Asia Pacific (HKG) region. Customers in these regions can now synthesize 60+ standard voices available in 29 languages in the Polly portfolio. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-polly-launches-in-bah-and-hkg-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-security-hub-releases-integrations-with-4-new-partners/">AWS Security Hub releases integrations with 4 new partners</a></h3> 
+            <div class="date">
+              Posted On: Jan 15, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/security-hub/">AWS Security Hub</a> has added <b>4</b> new external partner integrations bringing its total <b>47</b> integrations, including <b>41 </b>external partner integrations and <b>6</b> AWS service integrations. AWS Security Hub now supports integrations with IBM QRadar (a Security Information and Event Management or SIEM platform), Slack (a chat and instant messaging product), ServiceNow ITSM (a ticketing system), and ServiceNow SecOps (a Security Orchestration, Automation, and Response or SOAR system). Each of these integrations helps Security Hub customers take action on findings and provides a simple way to send findings from Security Hub to the partner’s product. Setting up the integration only requires deployment of a AWS CloudFormation template. The IBM QRadar integration with AWS Security Hub also supports sending findings from QRadar to Security Hub. To learn more, visit the Integration pages in the Security Hub console and click on the &quot;Configuration&quot; link for the partner to learn more about the integration and how to set it up. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-security-hub-releases-integrations-with-4-new-partners/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-now-offers-nvidia-quadro-virtual-workstations-for-ec2-g4-instances-at-no-additional-cost/">AWS Now Offers NVIDIA Quadro Virtual Workstations for EC2 G4 Instances at No Additional Cost</a></h3> 
+            <div class="date">
+              Posted On: Jan 14, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We are pleased to announce that customers who require the world’s most powerful professional graphics can now use EC2 G4 instances to setup NVIDIA Quadro Virtual Workstations (Quadro vWS) at no additional cost.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-now-offers-nvidia-quadro-virtual-workstations-for-ec2-g4-instances-at-no-additional-cost/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-transit-gateway-now-available-stockholm-region/">AWS Transit Gateway is Now Available in the Europe (Stockholm) AWS Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 14, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/transit-gateway/" target="_blank">AWS Transit Gateway</a> is now available in the Europe (Stockholm) AWS Region along with the support for AWS Direct Connect. AWS Transit Gateway enables customers to connect thousands of Amazon Virtual Private Clouds (Amazon VPCs) and their on-premises networks using a single gateway. As you grow the number of workloads across multiple AWS accounts, you need to scale your networks, better control your policies, and effectively monitor your resources.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-transit-gateway-now-available-stockholm-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-device-farm-announces-desktop-browser-testing-using-selenium/">AWS Device Farm announces Desktop Browser Testing using Selenium</a></h3> 
+            <div class="date">
+              Posted On: Jan 14, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Device Farm now lets you test your web applications against different desktop versions of Chrome, Firefox, and Internet Explorer browsers that are hosted in the AWS Cloud. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-device-farm-announces-desktop-browser-testing-using-selenium/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-matillion-etl-for-amazon-redshift-on-aws/">New Quick Start deploys Matillion ETL for Amazon Redshift on AWS</a></h3> 
+            <div class="date">
+              Posted On: Jan 14, 2020 
+            </div> 
+            <div class="description"> 
+             <p>This Quick Start deploys Matillion ETL for Amazon Redshift on the Amazon Web Services (AWS) Cloud&nbsp;in either a single instance with an Amazon Aurora database or a high availability (HA) cluster in about 20 minutes, following AWS best practices.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-matillion-etl-for-amazon-redshift-on-aws/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-adds-support-amazon-elastic-cloud-compute-instance-backup/">AWS Backup adds support for Amazon Elastic Cloud Compute (EC2) instance backup</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Backup automates backup and recovery jobs for Amazon EC2 instances without the need for custom scripts or third-party solutions, saving time and simplifying the backup process. Customers that use EC2 instances will now be able to perform their data protection requirements at the EC2 level, backing up both the Amazon Machine Instance (AMI) and the attached Amazon Elastic Block Store (EBS) volumes. You can now select an EC2 instance from the AWS Backup console, take an on-demand backup, or assign EC2 instances to a backup plan. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-adds-support-amazon-elastic-cloud-compute-instance-backup/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-marketplace-offers-new-pricing-options-for-container-based-software/">AWS Marketplace Offers New Pricing options for Container-based Software</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Marketplace, a curated digital catalog with over 230,000 active customers, has announced more pricing options for Container-based software. Starting today, you can find software that is billed on-demand based on new consumption units, such as the number of worker nodes managed. You can also purchase contracts for 1 year or longer to secure the best price for your commitment. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-marketplace-offers-new-pricing-options-for-container-based-software/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-lightsail-expands-selection-of-instance-blueprints/">Amazon Lightsail expands selection of instance blueprints</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Lightsail now offers Ghost and Django blueprints. With these additions, Amazon Lightsail expands its selection of blueprints and makes it easier to create blogs and web applications with just a few clicks. Lightsail offers a curated selection of preconfigured application stacks so you can easily find the software you need for your project. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-lightsail-expands-selection-of-instance-blueprints/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-delivers-fast-restore-experience-amazon-efs-item-level-recovery/">AWS Backup Delivers Fast Restore Experience for Amazon Elastic File System (EFS) Item-Level Recovery</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Backup now provides a streamlined experience for Amazon Elastic File System (EFS) Item-Level Recovery. You can now use AWS Backup to perform granular recovery of individual files or folders from Amazon EFS backups using a centralized console, for a simplified and fast restore experience, to meet more stringent Recovery Time Objective (RTO) requirements. To get started, choose the “Item-level Restore” restore type and provide one or more paths you want to recover using the AWS Backup console, SDK or CLI. This release is a continuation of our commitment to make data protection as streamlined and scalable as possible for our customers.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-delivers-fast-restore-experience-amazon-efs-item-level-recovery/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-supports-cross-region-backup/">AWS Backup supports Cross-Region Backup</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Backup now supports cross-region backup, enabling AWS customers to copy backups across multiple services to different regions. Cross-region backup offers a centralized solution to store a copy of backup data more than a region away from production data, helping you to more easily meet business continuity, disaster recovery, and compliance requirements. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-backup-supports-cross-region-backup/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-elastic-file-system-amazon-efs-now-supports-aws-identity-and-access-management-iam-for-network-file-system-clients/">Amazon Elastic File System now supports AWS Identity and Access Management for Network File System clients</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now use AWS Identity and Access Management (IAM) to manage Network File System (NFS) access for Amazon Elastic File System (Amazon EFS). You can use IAM roles to identify NFS clients with cryptographic security and use IAM policies to manage client-specific permissions. This new capability provides a simplified way to manage access at scale in NFS environments and is complementary to network-based security controls. With IAM for NFS clients you can use the same tools and processes you use today for managing access to other AWS resources. Permission checks are logged to AWS CloudTrail so you can audit client access to your file system.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-elastic-file-system-amazon-efs-now-supports-aws-identity-and-access-management-iam-for-network-file-system-clients/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-elastic-file-system-introduces-efs-access-points/">Amazon Elastic File System introduces EFS Access Points</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Elastic File System (Amazon EFS) Access Points is a new EFS feature that simplifies providing applications access to shared data sets in an EFS file system. EFS Access Points work together with AWS IAM and enforce an operating system user and group, and a directory for every file system request made through the access point. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-elastic-file-system-introduces-efs-access-points/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ec2-spot-instances-stopped-started-similar-to-on-demand-instances/">Amazon EC2 Spot instances can now be stopped and started similar to On-Demand instances</a></h3> 
+            <div class="date">
+              Posted On: Jan 13, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now stop your Amazon EC2 Spot Instances backed by Amazon EBS and start them at will, instead of relying on the “Stop” interruption behavior to stop your Spot Instances when interrupted. Earlier, you could only terminate your Spot Instances but now you can stop your Spot Instances and start them from the user initiated stop state provided Spot capacity is available within your maximum price requirements. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ec2-spot-instances-stopped-started-similar-to-on-demand-instances/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-cognito-supports-cloudwatch-usage-metrics/">Amazon Cognito now supports CloudWatch Usage Metrics</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Cognito now supports <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Usage-Metrics.html">CloudWatch Usage Metrics</a>, making it easier for administrators to monitor, report and take automatic actions in case of an event in near real time. AWS customers can create CloudWatch dashboards for Amazon Cognito sign in and sign up metrics, and they can create CloudWatch alarms to watch specific metrics. This feature is available now in Amazon Cognito User Pools at no additional cost.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-cognito-supports-cloudwatch-usage-metrics/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/introducing-workload-shares-in-aws-well-architected-tool/">Introducing Workload Shares in AWS Well-Architected Tool</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p>The AWS Well-Architected Tool now offers you a simple way to share workloads with other AWS accounts. Many customers use multiple AWS accounts to provide administrative autonomy for their teams. With Workload Shares, you can now create workloads in the AWS account of your choice and share them with AWS accounts used by other members of your review team or with a centralized AWS account. This feature enables shared visibility into High Risk Issues (HRIs) identified in workloads and streamlines collaboration with other workload reviewers, such as a Cloud Center of Excellence Lead, a member of your AWS account team or an AWS Well-Architected Partner Program member. The Workload Shares feature can help you manage and drive down HRIs over time without requiring direct access to the AWS account where the workload is defined.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/introducing-workload-shares-in-aws-well-architected-tool/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-well-architected-tool-now-available-asia-pacific-seoul-region/">The AWS Well-Architected Tool is now available in the Asia Pacific (Seoul) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p>The AWS Well-Architected Tool is now available in the Asia Pacific (Seoul) Region and the tool has been localized into Korean. The AWS Well-Architected Tool helps you review your workloads against AWS architectural best practices, and provides guidance on improving your cloud architectures.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-well-architected-tool-now-available-asia-pacific-seoul-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-transfer-for-sftp-supports-vpc-security-groups-and-elastic-ip-addresses/">AWS Transfer for SFTP supports VPC Security Groups and Elastic IP addresses</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/sftp/" target="_blank">AWS Transfer for SFTP</a> (AWS SFTP) customers can now whitelist client IP addresses using Amazon Virtual Private Cloud (VPC) Security Groups, providing an additional layer of security to their SFTP servers. Customers can also associate Elastic IP addresses with their server’s endpoint, enabling end users behind firewalls to whitelist access to the endpoint.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-transfer-for-sftp-supports-vpc-security-groups-and-elastic-ip-addresses/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/cloudfront-kenya-bulgaria-greece-hungary-romania/">Amazon CloudFront launches in five new countries - Bulgaria, Greece, Hungary, Kenya, and Romania</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon CloudFront announces its first Edge Locations in five new countries: Sofia (Bulgaria), Athens (Greece), Budapest (Hungary), Nairobi (Kenya), and Bucharest (Romania). Viewers in these countries will now see, on average, up to a 50% reduction in first-byte latency when accessing content through CloudFront. In addition to these new countries, CloudFront also launched its first Edge location in Dusseldorf, Germany. With these new locations, CloudFront now has 216 Points of Presence in 84 cities across 42 countries. For more information about CloudFront’s global infrastructure, see <a href="https://aws.amazon.com/cloudfront/features/#Amazon_CloudFront_Infrastructure">Amazon CloudFront Infrastructure</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/cloudfront-kenya-bulgaria-greece-hungary-romania/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/the-amazon-builders-library-is-now-available-in-16-languages/">The Amazon Builders’ Library is Now Available in 16 Languages</a></h3> 
+            <div class="date">
+              Posted On: Jan 10, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now read <a href="/builders-library/" target="_blank">The Amazon Builders’ Library</a> in 16 different languages: Arabic, Indonesian, German, Spanish, Italian, Portuguese, French, Vietnamese, Turkish, Russian, Thai, Japanese, Korean, Chinese Simplified, Chinese Traditional, and the original English. To change to your preferred language, select the language in the upper right hand corner of your screen.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/the-amazon-builders-library-is-now-available-in-16-languages/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-workspaces-migrate-enables-migration-windows-desktop-workspaces-streaming-protocol-beta/">Amazon WorkSpaces Migrate Enables Migration to the Windows 10 Desktop Experience and the New WorkSpaces Streaming Protocol in Beta</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>We are excited to introduce the Amazon WorkSpaces migrate feature that enables you to bring your user volume data to a new bundle. You can leverage this feature to migrate your WorkSpaces from the Windows 7 Experience to the Windows 10 Desktop Experience, as well as from a PCoIP WorkSpace to a WSP-powered WorkSpace (WSP, WorkSpaces Streaming Protocol, is currently available&nbsp;in <a href="/workspaces/wsp/">beta</a>).<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-workspaces-migrate-enables-migration-windows-desktop-workspaces-streaming-protocol-beta/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-route-53-resolver-endpoints-for-hybrid-cloud-now-available-hong-kong-region/">Amazon Route 53 Resolver Endpoints for Hybrid Cloud Now Available in the Asia Pacific (Hong Kong) AWS Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now use Amazon Route 53 Resolver endpoints for hybrid cloud configurations in the Asia Pacific (Hong Kong) AWS Region.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-route-53-resolver-endpoints-for-hybrid-cloud-now-available-hong-kong-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-redshift-spectrum-launches-in-aws-china-ningxia-nwcd-region/">Amazon Redshift Spectrum launches in AWS China (Ningxia) Region, operated by NWCD</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Redshift Spectrum is now available in AWS China (Ningxia) region, operated by NWCD.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-redshift-spectrum-launches-in-aws-china-ningxia-nwcd-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-fsx-for-lustre-announces-aws-repository-for-lustre-clients/">Amazon FSx for Lustre Announces AWS Repository for Lustre Clients</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon FSx for Lustre is making it even easier to access high-performance FSx for Lustre file systems from Red Hat Enterprise Linux, CentOS, and Ubuntu with Lustre clients that are distributed from AWS repositories.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-fsx-for-lustre-announces-aws-repository-for-lustre-clients/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/access-resources-within-your-amazon-virtual-private-cloud-using-amazon-kinesis-data-analytics/">Access Resources within your Amazon Virtual Private Cloud using Amazon Kinesis Data Analytics</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now enable your <a href="/kinesis/data-analytics/">Amazon Kinesis Data Analytics</a> for Java applications to access resources within your Amazon Virtual Private Cloud (Amazon VPC). This feature was <a href="https://aws.amazon.com/about-aws/whats-new/2019/11/access-resources-within-your-amazon-virtual-private-cloud-using-amazon-kinesis-data-analytics/">previously announced</a> in four regions on November 25th, 2019 and is now available in all regions where Amazon Kinesis Data Analytics is available. For a list of where Amazon Kinesis Data Analytics is available, please see the <a href="/about-aws/global-infrastructure/regional-product-services/">AWS Region Table</a>. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/access-resources-within-your-amazon-virtual-private-cloud-using-amazon-kinesis-data-analytics/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-sqs-now-supports-1-minute-cloudwatch-metrics-in-all-commercial-regions/">Amazon SQS Now Supports 1-Minute CloudWatch Metrics In All Commercial Regions</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/sqs/" target="_blank">Amazon Simple Queue Service</a> (SQS) launched support for 1-minute Amazon CloudWatch metrics on <a href="/about-aws/whats-new/2019/12/amazon-sqs-now-supports-1-minute-cloudwatch-metrics/" target="_blank">Dec 11, 2019</a> in US East (Ohio), EU (Ireland), EU (Stockholm), and Asia Pacific (Tokyo) Regions. Starting today, you can set up Amazon CloudWatch metrics at 1-minute interval at no additional cost in all commercial regions. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-sqs-now-supports-1-minute-cloudwatch-metrics-in-all-commercial-regions/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-launches-public-roadmap/">AWS Elastic Beanstalk Launches Public Roadmap</a></h3> 
+            <div class="date">
+              Posted On: Jan 9, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now follow the public <a href="https://github.com/aws/elastic-beanstalk-roadmap">AWS Elastic Beanstalk roadmap</a> on GitHub to get updates on recently launched features, upcoming features, and to provide feedback on what you want us to support. You can create new issues to propose features or changes you would like to see, or comment on existing issues with feedback and suggestions. Visit <a href="https://github.com/aws/elastic-beanstalk-roadmap/projects/1">Elastic Beanstalk roadmap</a> to see several upcoming and just shipped features of Elastic Beanstalk.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-elastic-beanstalk-launches-public-roadmap/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-translate-introduces-batch-translation/">Amazon Translate introduces Batch Translation </a></h3> 
+            <div class="date">
+              Posted On: Jan 8, 2020 
+            </div> 
+            <div class="description"> 
+             <p><a href="/translate/">Amazon Translate</a> –<span style="mso-fareast-font-family: &quot;Times New Roman&quot;; mso-bidi-font-family: Calibri; mso-bidi-theme-font: minor-latin;"> a fully managed neural machine translation service that delivers high-quality, and affordable language translation in fifty-four languages – is now introducing Batch Translation. Starting today, customers have the option to translate a large collection of text or HTML documents stored in a folder in Amazon Simple Storage Service (S3) bucket using the new asynchronous Batch Translation service. This is in addition to the real-time (synchronous) translation service that is already available, giving you options that best fit your needs.</span></p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-translate-introduces-batch-translation/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-systems-manager-quick-setup-now-supports-targeting-all-instances/">AWS Systems Manager Quick Setup now supports targeting all instances</a></h3> 
+            <div class="date">
+              Posted On: Jan 8, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Systems Manager Quick Setup now enables you to target all instances in an account. Now, with a single click you can enable operational actions, like patch compliance scanning and instance inventory collection, across all instances in an account within an AWS Region. &nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-systems-manager-quick-setup-now-supports-targeting-all-instances/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/updated-quick-start-deploys-ibm-cloud-pak-for-data-on-red-hat-openshift-container-platform-cluster-on-aws/">Updated Quick Start deploys IBM Cloud Pak for Data on a Red Hat OpenShift Container Platform cluster on AWS</a></h3> 
+            <div class="date">
+              Posted On: Jan 8, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Web Services (AWS) and IBM are pleased to release a major update to the <a href="/quickstart/architecture/ibm-cloud-pak-for-data/" target="_blank">IBM Cloud Pak for Data on AWS Quick Start</a>. This updated Quick Start automatically deploys a multi-master, production instance of IBM Cloud Pak for Data on a Red Hat OpenShift Container Platform 3.11 cluster on the AWS Cloud. The cluster is created in a new or existing virtual private cloud (VPC) on Red Hat Enterprise Linux (RHEL) 7.7 instances, using the <a href="/quickstart/architecture/openshift/" target="_blank">Red Hat OpenShift on AWS Quick Start</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/updated-quick-start-deploys-ibm-cloud-pak-for-data-on-red-hat-openshift-container-platform-cluster-on-aws/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-ibaset-solumina-aws-cloud/">New Quick Start deploys iBASEt Solumina on the AWS Cloud</a></h3> 
+            <div class="date">
+              Posted On: Jan 7, 2020 
+            </div> 
+            <div class="description"> 
+             <p>This Quick Start deploys iBASEt Solumina Manufacturing Execution System (MES) on the Amazon Web Services (AWS) Cloud in about 1.5–2 hours.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/new-quick-start-deploys-ibaset-solumina-aws-cloud/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/introducing-aws-systems-manager-change-calendar/">Introducing AWS Systems Manager Change Calendar</a></h3> 
+            <div class="date">
+              Posted On: Jan 6, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Today, AWS announces Systems Manager Change Calendar, a new capability that helps you prevent changes to your AWS resources during important business events. Using Change Calendar, you can schedule calendar events to control the changes made to your AWS resources during events, such as public marketing promotions, when you expect high demand on your resources.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/introducing-aws-systems-manager-change-calendar/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-comprehend-launches-multi-label-custom-classification/">Amazon Comprehend launches multi-label custom classification</a></h3> 
+            <div class="date">
+              Posted On: Jan 6, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Comprehend now supports multi-label custom classification. With multi-label classification you can train models and classify your documents with more than one label. Prior to this launch, custom classification supported multi-class classification, which is used to assign a single unique label to your documents. You now have additional options to meet the needs of your application.&nbsp;</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-comprehend-launches-multi-label-custom-classification/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ses-now-lets-you-use-your-existing-ip-address-ranges-to-s/">Amazon SES now lets you use your existing IP address ranges to send email</a></h3> 
+            <div class="date">
+              Posted On: Jan 6, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon Simple Email Service (Amazon SES) now includes a feature called Bring Your Own IP (BYOIP), which makes it possible to use Amazon SES to send email through publicly-routable IP addresses that you already own.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-ses-now-lets-you-use-your-existing-ip-address-ranges-to-s/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-privatelink-supports-private-dns-names-internal-3rd-party-services/">AWS PrivateLink now supports Private DNS names for internal and 3rd party services</a></h3> 
+            <div class="date">
+              Posted On: Jan 6, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now access AWS PrivateLink based services privately from within your VPC using <a href="https://docs.aws.amazon.com/vpc/latest/userguide/vpce-interface.html#vpce-private-dns">Private DNS names</a> like <i>‘myinternalservice.mycompany.com’</i>. With this announcement, you can access your internal / 3rd party AWS PrivateLink based services, without making changes in your application to use the AWS specified public DNS Name or managing private DNS Names your own Route 53 Private Hosted Zones. <br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-privatelink-supports-private-dns-names-internal-3rd-party-services/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-direct-connect-supports-aws-transit-gateway-for-aws-asia-pacific-hong-kong-region/">AWS Direct Connect supports AWS Transit Gateway for AWS Asia Pacific (Hong Kong) Region</a></h3> 
+            <div class="date">
+              Posted On: Jan 6, 2020 
+            </div> 
+            <div class="description"> 
+             <p>AWS Direct Connect support for AWS Transit Gateway is now available in AWS Asia Pacific (Hong Kong) region. With this feature, customers can connect thousands of Amazon Virtual Private Clouds (Amazon VPCs) in multiple AWS Regions to their on-premises networks using 1/2/5/10 Gbps AWS Direct Connect connections.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/aws-direct-connect-supports-aws-transit-gateway-for-aws-asia-pacific-hong-kong-region/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-quicksight-launches-new-analytical-functions-athena-workgroup-and-presto-vpc-connector-support/">Amazon QuickSight launches new analytical functions, Athena Workgroup and Presto VPC connector support </a></h3> 
+            <div class="date">
+              Posted On: Jan 3, 2020 
+            </div> 
+            <div class="description"> 
+             <p>Amazon QuickSight makes available new math functions to perform advanced statistical calculations. These functions include logarithms (log()), natural logarithm (ln()), expotent (exp()), square root (sqrt()) and absolute (abs()). Additionally, QuickSight now supports level aware aggregations on RANK, DENSE RANK and PERCENTILE RANK functions. With this, you can compute these functions on your business metrics irrespective of the filters applied and aggregations performed on your visuals. To learn more, see <a href="https://docs.aws.amazon.com/quicksight/latest/user/level-aware-aggregations.html">here</a>.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/amazon-quicksight-launches-new-analytical-functions-athena-workgroup-and-presto-vpc-connector-support/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/data-deduplication-user-storage-quotas-other-features-available-amazon-fsx-file-systems/">Data Deduplication, user storage quotas, and other recently launched administration features are now available on all Amazon FSx file systems</a></h3> 
+            <div class="date">
+              Posted On: Jan 2, 2020 
+            </div> 
+            <div class="description"> 
+             <p> Amazon FSx for Windows File Server, a service that provides fully managed native Microsoft Windows file systems, has now made Data Deduplication, user storage quotas, and other administration features launched on November 20, 2019 available to all file systems. Until today, these features were available only on file systems created since November 20. Now, storage administrators can use these features on any existing Amazon FSx file system.</p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/data-deduplication-user-storage-quotas-other-features-available-amazon-fsx-file-systems/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+           <li class="directory-item text whats-new"> <h3><a href="//aws.amazon.com/about-aws/whats-new/2020/01/secure-aws-elemental-mediapackage-live-endpoints-using-cdn-authorization/">Secure AWS Elemental MediaPackage Live Endpoints Using CDN Authorization</a></h3> 
+            <div class="date">
+              Posted On: Jan 2, 2020 
+            </div> 
+            <div class="description"> 
+             <p>You can now restrict direct access to <a href="/mediapackage/">AWS Elemental MediaPackage</a> by securing requests for live content using CDN authorization. With CDN authorization, content requests require a specific HTTP origin header and authorization code. MediaPackage verifies this code before it serves any content. For instructions on how to configure CDN authorization for live endpoints, please refer to the <a href="https://docs.aws.amazon.com/mediapackage/latest/ug/working-cdn-auth.html">documentation pages</a>.<br /> </p> 
+            </div> 
+            <div class="reg-cta"> 
+             <b><a href="//aws.amazon.com/about-aws/whats-new/2020/01/secure-aws-elemental-mediapackage-live-endpoints-using-cdn-authorization/">Read More&nbsp;&raquo;</a></b> 
+            </div> </li> 
+          </ul> 
+         </div> 
+        </div> 
+       </div> 
+      </section> 
+     </main> 
+    </div> 
+   </div> 
+  </div> 
+  <footer id="aws-page-footer" class="m-page-footer" role="contentinfo"> 
+   <div data-url="https://dc.ads.linkedin.com/collect/?pid=3038&amp;fmt=gif" data-lb-comp="tracking-pixel"></div> 
+   <div data-lb-comp="google-rlsa-pixel"></div> 
+   <div class="data-attr-wrapper lb-none-v-margin lb-xb-grid-wrap" style="background-color:#242F3E;" data-da-type="so" data-da-so-type="viewport" data-da-so-language="en" data-da-so-category="monitoring" data-da-so-name="footer" data-da-so-version="a"> 
+    <div class="lb-xb-grid lb-row-max-large lb-snap lb-tiny-xb-1 lb-small-xb-3 lb-large-xb-5"> 
+     <div class="lb-xbcol"> 
+      <div class="data-attr-wrapper lb-small-hide lb-btn" data-da-type="so" data-da-so-type="viewport" data-da-so-language="en" data-da-so-category="monitoring" data-da-so-name="footer_buttons" data-da-so-url="all" data-da-so-version="footer_signin-mobile-default"> 
+       <a class="lb-btn-p-primary" href="https://console.aws.amazon.com/console/home?nc1=f_ct&amp;src=footer-signin-mobile" role="button"> <span> Sign In to the Console</span> </a> 
+      </div> 
+      <h3 id="Learn_About_AWS" class="lb-txt-none lb-txt-p-chromium lb-tiny-v-margin lb-h3 lb-title"> Learn About AWS</h3> 
+      <ul class="lb-txt-p-chromium lb-ul lb-list-style-none lb-li-micro-v-margin lb-tiny-ul-block" style="margin-bottom:0px;"> 
+       <li><a href="/what-is-aws/?nc1=f_cc" target="_blank">What Is AWS?</a></li> 
+       <li><a href="/what-is-cloud-computing/?nc1=f_cc" target="_blank">What Is Cloud Computing?</a></li> 
+       <li><a href="/devops/what-is-devops/?nc1=f_cc" target="_blank">What Is DevOps?</a></li> 
+       <li><a href="/containers/?nc1=f_cc" target="_blank">What Is a Container?</a></li> 
+       <li><a href="/big-data/datalakes-and-analytics/what-is-a-data-lake/?nc1=f_cc" target="_blank">What Is a Data Lake?</a></li> 
+       <li><a href="/security/?nc1=f_cc" target="_blank">AWS Cloud Security</a></li> 
+       <li><a href="/new/?nc1=f_cc" target="_blank">What's New</a></li> 
+       <li><a href="/blogs/?nc1=f_cc" target="_blank">Blogs</a></li> 
+       <li><a href="https://press.aboutamazon.com/press-releases/aws" target="_blank" title="Press Releases">Press Releases</a></li> 
+      </ul> 
+     </div> 
+     <div class="lb-xbcol"> 
+      <h3 id="Resources_for_AWS" class="lb-txt-none lb-txt-p-chromium lb-tiny-v-margin lb-h3 lb-title"> Resources for AWS</h3> 
+      <ul class="lb-txt-p-chromium lb-ul lb-list-style-none lb-li-micro-v-margin lb-tiny-ul-block" style="margin-bottom:0px;"> 
+       <li><a href="/getting-started/?nc1=f_cc" target="_blank">Getting Started</a></li> 
+       <li><a href="/training/?nc1=f_cc" target="_blank">Training and Certification</a></li> 
+       <li><a href="/solutions/?nc1=f_cc" target="_blank">AWS Solutions Portfolio</a></li> 
+       <li><a href="/architecture/?nc1=f_cc" target="_blank">Architecture Center</a></li> 
+       <li><a href="/faqs/?nc1=f_dr" target="_blank">Product and Technical FAQs</a></li> 
+       <li><a href="/resources/analyst-reports/?nc1=f_cc" target="_blank">Analyst Reports</a></li> 
+       <li><a href="/partners/?nc1=f_dr" target="_blank">AWS Partner Network</a></li> 
+      </ul> 
+     </div> 
+     <div class="lb-xbcol"> 
+      <h3 id="Developers_on_AWS" class="lb-txt-none lb-txt-p-chromium lb-tiny-v-margin lb-h3 lb-title"> Developers on AWS</h3> 
+      <ul class="lb-txt-p-chromium lb-ul lb-list-style-none lb-li-micro-v-margin lb-tiny-ul-block" style="margin-bottom:0px;"> 
+       <li><a href="/developer/?nc1=f_dr" target="_blank">Developer Center</a></li> 
+       <li><a href="/developer/tools/?nc1=f_dr" target="_blank">SDKs &amp; Tools</a></li> 
+       <li><a href="/developer/language/net/?nc1=f_dr" target="_blank">.NET on AWS</a></li> 
+       <li><a href="/developer/language/python/?nc1=f_dr" target="_blank">Python on AWS</a></li> 
+       <li><a href="/developer/language/java/?nc1=f_dr" target="_blank">Java on AWS</a></li> 
+       <li><a href="/developer/language/php/?nc1=f_cc" target="_blank">PHP on AWS</a></li> 
+       <li><a href="/developer/language/javascript/?nc1=f_dr" target="_blank">Javascript on AWS</a></li> 
+      </ul> 
+     </div> 
+     <div class="lb-xbcol"> 
+      <h3 id="Help" class="lb-txt-none lb-txt-p-chromium lb-tiny-v-margin lb-h3 lb-title"> Help</h3> 
+      <ul class="lb-txt-p-chromium lb-ul lb-list-style-none lb-li-micro-v-margin lb-tiny-ul-block" style="margin-bottom:0px;"> 
+       <li><a href="/contact-us/?nc1=f_m" target="_blank">Contact Us</a></li> 
+       <li><a href="/careers/?nc1=f_hi" target="_blank">AWS Careers</a></li> 
+       <li><a href="https://console.aws.amazon.com/support/home/?nc1=f_dr" target="_blank">File a Support Ticket</a></li> 
+       <li><a href="/premiumsupport/knowledge-center/?nc1=f_dr" target="_blank">Knowledge Center</a></li> 
+       <li><a href="/premiumsupport/?nc1=f_dr" target="_blank">AWS Support Overview</a></li> 
+       <li><a href="/legal/?nc1=f_cc" target="_blank">Legal</a></li> 
+      </ul> 
+      <div class="lb-mbox js-mbox" data-lb-comp="mbox" data-mbox="en_footer-v3_addl-help" data-lb-comp-ignore="true"> 
+      </div> 
+     </div> 
+     <div class="lb-xbcol"> 
+      <div class="lb-mbox js-mbox" data-lb-comp="mbox" data-mbox="en_footer-v3_cta" data-lb-comp-ignore="true"> 
+       <div class="data-attr-wrapper lb-tiny-hide lb-small-show lb-btn" data-da-type="so" data-da-so-type="viewport" data-da-so-language="en" data-da-so-category="monitoring" data-da-so-name="footer_buttons" data-da-so-url="all" data-da-so-version="footer_signup-default"> 
+        <a class="lb-btn-p-primary" href="https://portal.aws.amazon.com/gp/aws/developer/registration/index.html?nc1=f_ct&amp;src=default" role="button"> <span> Create an AWS Account</span> </a> 
+       </div> 
+      </div> 
+      <div class="lb-xb-grid-wrap" style="padding-left:0px; margin-top:20px;"> 
+       <div class="lb-xb-grid lb-row-max-large lb-xb-equal-height lb-snap lb-gutter-collapse lb-vgutter-collapse lb-tiny-xb-auto"> 
+        <div class="lb-xbcol"> 
+         <div class="lb-data-attr-wrapper data-attr-wrapper" data-da-so-category="monitoring" data-da-so-url="all" data-da-so-version="twitter" data-da-so-language="en" data-da-so-name="footer-socials" data-da-type="so" data-da-so-type="viewport"> 
+          <a class="lb-txt-none lb-txt-p-chromium lb-none-pad lb-txt" style="padding-left:0px; padding-right:12px;" href="https://twitter.com/awscloud" target="_blank" title="Twitter"> <i class="icon-twitter"></i></a> 
+         </div> 
+        </div> 
+        <div class="lb-xbcol"> 
+         <div class="lb-data-attr-wrapper data-attr-wrapper" data-da-so-category="monitoring" data-da-so-url="all" data-da-so-version="facebook" data-da-so-language="en" data-da-so-name="footer-socials" data-da-type="so" data-da-so-type="viewport"> 
+          <a class="lb-txt-none lb-txt-p-chromium lb-none-pad lb-none-v-margin lb-txt" style="padding-right:12px;" href="https://www.facebook.com/amazonwebservices" target="_blank" title="Facebook"> <i class="icon-facebook"></i></a> 
+         </div> 
+        </div> 
+        <div class="lb-xbcol"> 
+         <div class="lb-data-attr-wrapper data-attr-wrapper" data-da-so-category="monitoring" data-da-so-url="all" data-da-so-version="twitch" data-da-so-language="en" data-da-so-name="footer-socials" data-da-type="so" data-da-so-type="viewport"> 
+          <a class="lb-txt-none lb-txt-p-chromium lb-none-pad lb-txt" style="padding-right:12px;" href="https://www.twitch.tv/aws" target="_blank" title="Twitch"> <i class="icon-twitch"></i></a> 
+         </div> 
+        </div> 
+        <div class="lb-xbcol"> 
+         <div class="lb-data-attr-wrapper data-attr-wrapper" data-da-so-category="monitoring" data-da-so-url="all" data-da-so-version="aws-podcast" data-da-so-language="en" data-da-so-name="footer-socials" data-da-type="so" data-da-so-type="viewport"> 
+          <a class="lb-txt-none lb-txt-p-chromium lb-none-pad lb-txt" style="padding-right:12px;" href="https://aws.amazon.com/podcasts/aws-podcast/" target="_blank" title="Podcast"> <i class="icon-podcast"></i></a> 
+         </div> 
+        </div> 
+        <div class="lb-xbcol"> 
+         <div class="lb-data-attr-wrapper data-attr-wrapper" data-da-so-category="monitoring" data-da-so-url="all" data-da-so-version="newsletter" data-da-so-language="en" data-da-so-name="footer-socials" data-da-type="so" data-da-so-type="viewport"> 
+          <a class="lb-txt-none lb-txt-p-chromium lb-none-pad lb-txt" style="padding-right:12px;" href="https://pages.awscloud.com/communication-preferences?trk=homepage" target="_blank" title="Email"> <i class="icon-envelope-o"></i></a> 
+         </div> 
+        </div> 
+       </div> 
+      </div> 
+      <div class="lb-txt-normal lb-txt-white lb-txt-14 lb-rtxt" style="color:#eaeded; margin-top:0px;"> 
+       <div>
+         Amazon is an Equal Opportunity Employer: 
+        <i> Minority / Women / Disability / Veteran / Gender Identity / Sexual Orientation / Age.</i> 
+       </div> 
+      </div> 
+     </div> 
+    </div> 
+   </div> 
+   <div class="lb-none-pad lb-none-v-margin lb-xb-grid-wrap" style="background-color:#242F3E;"> 
+    <div class="lb-xb-grid lb-row-max-large lb-snap lb-tiny-xb-1"> 
+     <div class="lb-xbcol"> 
+      <ul class="lb-txt-p-chromium lb-tiny-iblock lb-none-v-margin lb-ul lb-list-style-none lb-li-micro-v-margin lb-tiny-ul-iblock"> 
+       <li class="lb-txt-bold">Language</li> 
+       <li data-language="ar"><a href="https://aws.amazon.com/ar/?nc1=h_ls">عربي</a></li> 
+       <li data-language="id"><a href="https://aws.amazon.com/id/?nc1=h_ls">Bahasa Indonesia</a></li> 
+       <li data-language="de"><a href="https://aws.amazon.com/de/?nc1=h_ls">Deutsch</a></li> 
+       <li data-language="en"><a href="https://aws.amazon.com/?nc1=h_ls">English</a></li> 
+       <li data-language="es"><a href="https://aws.amazon.com/es/?nc1=h_ls">Espa&ntilde;ol</a></li> 
+       <li data-language="fr"><a href="https://aws.amazon.com/fr/?nc1=h_ls">Fran&ccedil;ais</a></li> 
+       <li data-language="it"><a href="https://aws.amazon.com/it/?nc1=h_ls">Italiano</a></li> 
+       <li data-language="pt"><a href="https://aws.amazon.com/pt/?nc1=h_ls">Portugu&ecirc;s</a></li> 
+       <li data-language="vi"><a href="https://aws.amazon.com/vi/?nc1=f_ls">Tiếng Việt</a></li> 
+       <li data-language="tr"><a href="https://aws.amazon.com/tr/?nc1=h_ls">T&uuml;rk&ccedil;e</a></li> 
+       <li data-language="ru"><a href="https://aws.amazon.com/ru/?nc1=h_ls">Ρусский</a></li> 
+       <li data-language="th"><a href="https://aws.amazon.com/th/?nc1=f_ls">ไทย</a></li> 
+       <li data-language="jp"><a href="https://aws.amazon.com/jp/?nc1=h_ls">日本語</a></li> 
+       <li data-language="ko"><a href="https://aws.amazon.com/ko/?nc1=h_ls">한국어</a></li> 
+       <li data-language="cn"><a href="https://aws.amazon.com/cn/?nc1=h_ls">中文 (简体)</a></li> 
+       <li data-language="tw"><a href="https://aws.amazon.com/tw/?nc1=h_ls">中文 (繁體)</a></li> 
+      </ul> 
+     </div> 
+    </div> 
+   </div> 
+   <div class="lb-none-pad lb-none-v-margin lb-xb-grid-wrap" style="background-color:#EAEDED; padding-top:5px;"> 
+    <div class="lb-xb-grid lb-row-max-large lb-snap lb-tiny-xb-1"> 
+     <div class="lb-xbcol"> 
+      <ul class="lb-txt-p-squid-ink lb-none-v-margin lb-ul lb-list-style-none lb-li-none-v-margin lb-tiny-ul-iblock"> 
+       <li><a href="https://aws.amazon.com/privacy/?nc1=f_pr">Privacy</a></li> 
+       <li>|</li> 
+       <li><a href="https://aws.amazon.com/terms/?nc1=f_pr">Site Terms</a></li> 
+       <li>|</li> 
+       <li>&copy; 2020, Amazon Web Services, Inc. or its affiliates. All rights reserved.</li> 
+      </ul> 
+     </div> 
+    </div> 
+   </div> 
+  </footer> 
+  <div id="aws-page-end"></div> 
+  <div id="lb-page-end"></div> 
+  <script>require(['jquery', 'scripts']);</script> 
+  <script src="https://a0.awsstatic.com/pre-offer/1.0.11/content/sitePriv/main.js" async=""></script> 
+  <script src="https://a0.awsstatic.com/da/js/1.0.38/aws-da.js"></script> 
+  <!-- SiteCatalyst code version: H.25.1. Copyright 1996-2012 Adobe, Inc. All Rights Reserved --> 
+  <script><!--
+/************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+var s_code=s.t();if(s_code)document.write(s_code)//--></script> 
+  <script><!--
+if(navigator.appVersion.indexOf('MSIE')>=0)document.write(unescape('%3C')+'\!-'+'-')
+//--></script> 
+  <noscript> 
+   <img src="//amazonwebservices.d2.sc.omtrdc.net/b/ss/awsamazonalldev2/1/H.25.1--NS/0" height="1" width="1" border="0" alt="" /> 
+  </noscript> 
+  <!--/DO NOT REMOVE/--> 
+  <!-- End SiteCatalyst code version: H.25.1. --> 
+  <!--[if lte IE 9]>
+  <script>
+    jQuery = $ = undefined;
+  </script>
+  <p class="deprecated-browser-support-message">
+    You are using an <strong>outdated</strong> browser. Please upgrade to Internet Explorer 11 or another modern browser to improve your experience.<img src="https://fls-na.amazon.com/1/action-impressions/1/OE/aws-mktg/action/awsm_:comp_DeprecatedBrowser@v=1:u=c?dataset=LIVE:PROD&instance=PUB&client=dsk&method=NA&marketplaceId=A12QK8IU0H0XW5&requestId=ABCDEFGHIJKLMNOPQRST&session=123-1234567-1234567"
+           alt="deprecated-browser pixel tag" />
+      </p>
+<![endif]--> 
+  <script>
+  if (document.documentMode === 10) {
+    var msg = 'You are using an <strong>outdated</strong> browser. Please upgrade to Internet Explorer 11 or another modern browser to improve your experience.';
+    $('html').addClass('unsupported-version');
+    $(document.body).append('<p class="deprecated-browser-support-message">' + msg + '<img src="https://fls-na.amazon.com/1/action-impressions/1/OE/aws-mktg/action/awsm_:comp_DeprecatedBrowser@v=1:u=c?dataset=LIVE:PROD&instance=PUB&client=dsk&method=NA&marketplaceId=A12QK8IU0H0XW5&requestId=ABCDEFGHIJKLMNOPQRST&session=123-1234567-1234567" alt="deprecated-browser pixel tag" /></p>');
+    jQuery = $ = undefined;
+  }
+</script> 
+  <!-- updated_at: 2020-02-05T13:39:16.860-0800 -->  
+ </body>
+</html>


### PR DESCRIPTION
- AWS doesn't seem to want to publish daily on the month pages anymore, so switching to use the year page by default without breaking API

- Added `Last()` function to enable limiting number of return values

- Switched most time functions to use the `FetchYear()` function to avoid filtering twice with `ThisMonth()`