### PR TITLE
fix: modified post URL generation

### DIFF
--- a/news/announcements.go
+++ b/news/announcements.go
@@ -118,7 +118,7 @@ func Fetch(year int, month int) (Announcements, error) {
 		announcement := Announcement{}
 		_, postDateMonth, _ := item.Item.AdditionalFields.PostDateTime.Date()
 		if postDateMonth == time.Now().Month() {
-			announcement.Link = awsWhatsNewPostBaseURL + item.Item.Name
+			announcement.Link = awsWhatsNewPostBaseURL + item.Item.AdditionalFields.HeadlineURL
 			announcement.PostDate = item.Item.AdditionalFields.PostDateTime.Format(time.RFC3339)
 			announcement.Title = item.Item.AdditionalFields.Headline
 			announcements = append(announcements, announcement)
@@ -138,7 +138,7 @@ func FetchYear(year int) (Announcements, error) {
 
 	for _, item := range items.Items {
 		announcement := Announcement{}
-		announcement.Link = fmt.Sprintf("%s/%s", awsWhatsNewPostBaseURL, item.Item.Name)
+		announcement.Link = fmt.Sprintf("%s/%s", awsWhatsNewPostBaseURL, item.Item.AdditionalFields.HeadlineURL)
 		announcement.PostDate = item.Item.DateCreated
 		announcement.Title = item.Item.AdditionalFields.Headline
 		announcements = append(announcements, announcement)


### PR DESCRIPTION
This PR updates the Post URL created when posted. With the introduction of `v2`, we can no longer use `item.Item.Name` but instead have to use `item.Item.AdditionalFields.HeadlineURL`.

This is what URLs look like now:

`https://aws.amazon.compodxfp7jzfbncdufub1wmn/`

With the fix we get this `https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-cloudwatch-logs-announces-live-tail-streaming-cli-support`